### PR TITLE
Add a safe adoption path for existing changelogs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,9 +7,11 @@ Version 0.2.0
 To be released.
 
  -  Added `sacho import-unreleased` for converting an existing materialized
-    unreleased region into fragments without rewriting released history.
+    unreleased region into fragments without rewriting released history.  [[#1]]
  -  Added interactive section suggestions to `sacho init` based on headings
-    found across an existing changelog.
+    found across an existing changelog.  [[#1]]
+
+[#1]: https://github.com/dahlia/sacho/issues/1
 
 
 Version 0.1.0

--- a/README.md
+++ b/README.md
@@ -147,20 +147,36 @@ state that never shipped.
 Basic workflow
 --------------
 
-With `sacho` on your `PATH`, initialize it at the repository root and choose
-the version you are preparing:
+With `sacho` on your `PATH`, initialize it at the repository root:
 
 ~~~~ sh
 sacho init
-sacho next 1.2.0
 ~~~~
 
 Initialization creates *sacho.toml*, *changes.d/*, and *CHANGES.md*. It also
 sets up the merge integration supported by the detected version-control
 system. The interactive setup can infer an issue-link template from the
-repository URL and offer to install a Git pre-commit hook. Repository
+repository URL, offer headings found across an existing changelog as section
+configuration, and offer to install a Git pre-commit hook. Repository
 integrations use the executable that ran `init`; pass
 `--integration-executable PATH` to use another executable.
+
+If an existing *CHANGES.md* already has entries under `Unreleased` or
+`Version X`, import them before creating new fragments:
+
+~~~~ sh
+sacho import-unreleased
+~~~~
+
+Sacho shows any normalization diff before writing. The import creates one root
+fragment, or one fragment per populated configured section, records `X` as the
+next version when present, and leaves every released section unchanged.
+
+If the import did not infer a version, choose the version you are preparing:
+
+~~~~ sh
+sacho next 1.2.0
+~~~~
 
 Create one fragment for each user-visible change, then edit the path printed by
 the command:

--- a/changes.d/import-unreleased.md
+++ b/changes.d/import-unreleased.md
@@ -1,4 +1,4 @@
  -  Added `sacho import-unreleased` for converting an existing materialized
-    unreleased region into fragments without rewriting released history.
+    unreleased region into fragments without rewriting released history.  [[#1]]
  -  Added interactive section suggestions to `sacho init` based on headings
-    found across an existing changelog.
+    found across an existing changelog.  [[#1]]

--- a/changes.d/import-unreleased.md
+++ b/changes.d/import-unreleased.md
@@ -1,18 +1,4 @@
-Sacho changelog
-===============
-
-Version 0.2.0
--------------
-
-To be released.
-
  -  Added `sacho import-unreleased` for converting an existing materialized
     unreleased region into fragments without rewriting released history.
  -  Added interactive section suggestions to `sacho init` based on headings
     found across an existing changelog.
-
-
-Version 0.1.0
--------------
-
-Initial release.  Released on July 21, 2026.

--- a/crates/sacho/src/cli.rs
+++ b/crates/sacho/src/cli.rs
@@ -1,5 +1,5 @@
 use std::io::{self, IsTerminal, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::SystemTime;
 
@@ -12,11 +12,13 @@ use sacho::commands::{
     InitOptions, InitResult, MutationCleanupWarning, NextOptions, ReleaseDate, ReleaseOptions,
     ShowOptions, SyncOptions, SyncPlan, add_fragment, apply_format, apply_merge_driver,
     apply_release, apply_sync, carry, check, commit_message_hook, compile_unreleased,
-    infer_repository_url, init_repository, mercurial_update_hook, plan_format, plan_release,
-    plan_sync, reference_transaction_hook, set_next_version, show,
+    infer_repository_url, infer_section_paths, init_repository, initialization_root,
+    mercurial_update_hook, plan_format, plan_release, plan_sync, reference_transaction_hook,
+    set_next_version, show, suggest_section_directory,
 };
 use sacho::merge::{MergeDriverOptions, MergeDriverResult};
-use sacho::{Error, Repository};
+use sacho::released::discover_section_candidates;
+use sacho::{Error, Repository, SectionConfig};
 
 const HELP_LICENSE_NOTICE: &str = "Copyright (C) 2026 Hong Minhee\n\
 Sacho is free software under GNU GPLv3 only and comes with ABSOLUTELY NO WARRANTY.\n\
@@ -549,6 +551,12 @@ fn resolve_init_options(
         let changelog_path = prompt("Changelog path", "CHANGES.md")?;
         let fragment_directory = prompt("Fragment directory", "changes.d")?;
         let materialize = prompt_bool("Materialize unreleased changelog", true)?;
+        let root = initialization_root(".");
+        let sections = resolve_interactive_sections(
+            &root,
+            Path::new(&changelog_path),
+            Path::new(&fragment_directory),
+        )?;
         let repository_url = resolve_interactive_repository_url(repository_url)?;
         let install_hook = if install_hook {
             true
@@ -568,6 +576,7 @@ fn resolve_init_options(
             install_hook,
             append_existing_hook,
             repository_url,
+            sections,
         })
     } else {
         Ok(InitOptions {
@@ -578,8 +587,124 @@ fn resolve_init_options(
             install_hook,
             append_existing_hook: false,
             repository_url,
+            sections: Vec::new(),
         })
     }
+}
+
+fn resolve_interactive_sections(
+    root: &Path,
+    changelog_path: &Path,
+    fragment_directory: &Path,
+) -> Result<Vec<SectionConfig>, CliReport> {
+    if root.join(Repository::CONFIG_FILE).exists() {
+        return Ok(Vec::new());
+    }
+    let path = root.join(changelog_path);
+    if !path.is_file() {
+        return Ok(Vec::new());
+    }
+    let changelog = std::fs::read_to_string(&path).map_err(|source| Error::ReadFile {
+        path: path.clone(),
+        source,
+    })?;
+    let document_title = root.file_name().and_then(|name| name.to_str()).map_or_else(
+        || String::from("Changelog"),
+        |name| format!("{name} changelog"),
+    );
+    let candidates = discover_section_candidates(&changelog, &document_title, "To be released.");
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    println!("Possible changelog sections:");
+    for (index, candidate) in candidates.iter().enumerate() {
+        let occurrence_word = if candidate.occurrences == 1 {
+            "occurrence"
+        } else {
+            "occurrences"
+        };
+        let unreleased = if candidate.appears_in_unreleased {
+            ", unreleased"
+        } else {
+            ""
+        };
+        println!(
+            "  {}. {} ({} {}{})",
+            index + 1,
+            candidate.id,
+            candidate.occurrences,
+            occurrence_word,
+            unreleased
+        );
+    }
+    let selected = loop {
+        let answer = prompt("Select sections by number, comma-separated", "")?;
+        match parse_section_selection(&answer, candidates.len()) {
+            Ok(selected) => break selected,
+            Err(error) => eprintln!("{error}"),
+        }
+    };
+    let mut sections = Vec::new();
+    let mut used_directories = Vec::new();
+    for index in selected {
+        let candidate = &candidates[index];
+        let suggested = suggest_section_directory(&candidate.id, &used_directories);
+        let directory = PathBuf::from(prompt(
+            &format!("Fragment directory for {}", candidate.id),
+            &suggested.display().to_string(),
+        )?);
+        used_directories.push(directory.clone());
+        let suggested_paths =
+            infer_section_paths(root, &candidate.id, &directory, fragment_directory)?;
+        let paths_answer = prompt(
+            &format!("Paths for {} (comma-separated; '-' for none)", candidate.id),
+            &suggested_paths.join(", "),
+        )?;
+        let paths = if paths_answer == "-" {
+            Vec::new()
+        } else {
+            paths_answer
+                .split(',')
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(str::to_owned)
+                .collect()
+        };
+        sections.push(SectionConfig {
+            id: candidate.id.clone(),
+            directory,
+            paths,
+        });
+    }
+    Ok(sections)
+}
+
+fn parse_section_selection(answer: &str, candidate_count: usize) -> Result<Vec<usize>, CliReport> {
+    if answer.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut selected = Vec::new();
+    for part in answer.split(',') {
+        let number = part.trim().parse::<usize>().map_err(|_| Error::Usage {
+            message: format!("invalid section number {:?}", part.trim()),
+        })?;
+        if number == 0 || number > candidate_count {
+            return Err(Error::Usage {
+                message: format!("section number {number} is outside 1..={candidate_count}"),
+            }
+            .into());
+        }
+        let index = number - 1;
+        if selected.contains(&index) {
+            return Err(Error::Usage {
+                message: format!("section number {number} was selected more than once"),
+            }
+            .into());
+        }
+        selected.push(index);
+    }
+    Ok(selected)
 }
 
 fn resolve_interactive_repository_url(
@@ -863,6 +988,18 @@ mod tests {
             optional_prompt_value(String::from("https://example.com/repo")),
             Some(String::from("https://example.com/repo"))
         );
+    }
+
+    #[test]
+    fn section_selection_parser_preserves_order_and_rejects_bad_numbers() {
+        assert_eq!(parse_section_selection("", 3).expect("empty"), Vec::new());
+        assert_eq!(
+            parse_section_selection("3, 1", 3).expect("selection"),
+            vec![2, 0]
+        );
+        assert!(parse_section_selection("1,1", 3).is_err());
+        assert!(parse_section_selection("4", 3).is_err());
+        assert!(parse_section_selection("core", 3).is_err());
     }
 
     #[test]

--- a/crates/sacho/src/cli.rs
+++ b/crates/sacho/src/cli.rs
@@ -9,12 +9,13 @@ use jiff::{Timestamp, civil};
 use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme, Report};
 use sacho::commands::{
     AddOptions, CarryOptions, CheckOptions, CheckReport, CompileOptions, FormatOptions,
-    InitOptions, InitResult, MutationCleanupWarning, NextOptions, ReleaseDate, ReleaseOptions,
-    ShowOptions, SyncOptions, SyncPlan, add_fragment, apply_format, apply_merge_driver,
-    apply_release, apply_sync, carry, check, commit_message_hook, compile_unreleased,
-    infer_repository_url, infer_section_paths, init_repository, initialization_root,
-    mercurial_update_hook, plan_format, plan_release, plan_sync, reference_transaction_hook,
-    set_next_version, show, suggest_section_directory,
+    ImportUnreleasedOptions, ImportUnreleasedPlan, InitOptions, InitResult, MutationCleanupWarning,
+    NextOptions, ReleaseDate, ReleaseOptions, ShowOptions, SyncOptions, SyncPlan, add_fragment,
+    apply_format, apply_import_unreleased, apply_merge_driver, apply_release, apply_sync, carry,
+    check, commit_message_hook, compile_unreleased, infer_repository_url, infer_section_paths,
+    init_repository, initialization_root, mercurial_update_hook, plan_format,
+    plan_import_unreleased, plan_release, plan_sync, reference_transaction_hook, set_next_version,
+    show, suggest_section_directory,
 };
 use sacho::merge::{MergeDriverOptions, MergeDriverResult};
 use sacho::released::discover_section_candidates;
@@ -181,6 +182,13 @@ enum Command {
         /// Released version whose entries should be carried.
         #[arg(help = "Released version whose entries should be carried")]
         version: String,
+    },
+
+    /// Import the materialized unreleased region into fragments.
+    ImportUnreleased {
+        /// Apply even when normalized fragment output changes the region.
+        #[arg(long, help = "Apply even when normalization changes the changelog")]
+        force: bool,
     },
 
     /// Resolve changelog merge conflicts by recompiling fragments.
@@ -355,6 +363,22 @@ impl Cli {
                 print_mutation_cleanup_warnings("sacho carry", &result.cleanup_warnings);
                 Ok(ExitCode::SUCCESS)
             }
+            Command::ImportUnreleased { force } => {
+                let repo = Repository::open_existing(".").map_err(CliReport::from)?;
+                let plan = plan_import_unreleased(&repo, ImportUnreleasedOptions { force })?;
+                if !confirm_import_unreleased_plan(&plan)? {
+                    return Ok(ExitCode::from(2));
+                }
+                let result = apply_import_unreleased(&repo, plan)?;
+                print_mutation_cleanup_warnings(
+                    "sacho import-unreleased",
+                    &result.cleanup_warnings,
+                );
+                for path in result.written_fragments {
+                    println!("{}", path.display());
+                }
+                Ok(ExitCode::SUCCESS)
+            }
             Command::MergeDriver {
                 original,
                 current,
@@ -497,6 +521,29 @@ fn confirm_sync_plan(plan: &SyncPlan, formatting_command: Option<&str>) -> Resul
         eprintln!("synchronization cancelled; the repository was not changed");
         Ok(false)
     }
+}
+
+fn confirm_import_unreleased_plan(plan: &ImportUnreleasedPlan) -> Result<bool, CliReport> {
+    if !plan.requires_confirmation() {
+        return Ok(true);
+    }
+    let Some(diff) = &plan.diff else {
+        return Ok(true);
+    };
+    let interactive = sync_should_prompt(io::stdin().is_terminal(), io::stdout().is_terminal());
+    if interactive {
+        print!("{diff}");
+        println!("the imported fragments normalize the materialized unreleased region");
+        if prompt_bool("Apply this import", false)? {
+            return Ok(true);
+        }
+        eprintln!("import cancelled; the repository was not changed");
+    } else {
+        eprint!("{diff}");
+        eprintln!("the imported fragments normalize the materialized unreleased region");
+        eprintln!("rerun with `sacho import-unreleased --force` to apply it non-interactively");
+    }
+    Ok(false)
 }
 
 fn sync_should_prompt(stdin_terminal: bool, stdout_terminal: bool) -> bool {

--- a/crates/sacho/src/commands.rs
+++ b/crates/sacho/src/commands.rs
@@ -792,7 +792,7 @@ pub fn suggest_section_directory(id: &str, used: &[PathBuf]) -> PathBuf {
         slug.push_str("section");
     }
 
-    for suffix in 1.. {
+    for suffix in 1..=used.len() + 1 {
         let candidate = if suffix == 1 {
             PathBuf::from(&slug)
         } else {
@@ -802,7 +802,7 @@ pub fn suggest_section_directory(id: &str, used: &[PathBuf]) -> PathBuf {
             return candidate;
         }
     }
-    unreachable!("an unbounded numeric suffix must produce an unused path")
+    unreachable!("one more candidate than used paths must produce an unused path")
 }
 
 /// Finds repository directories whose basename resembles a section.
@@ -848,7 +848,7 @@ pub fn infer_section_paths(
                 continue;
             }
             let path = relative.join(entry.file_name());
-            if path == fragment_directory || path.starts_with(fragment_directory) {
+            if path == fragment_directory {
                 continue;
             }
             let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
@@ -874,10 +874,7 @@ pub fn infer_section_paths(
         .and_then(OsStr::to_str)
         .unwrap_or_default()
         .to_ascii_lowercase();
-    let mut wanted = vec![id_stem];
-    if !directory_stem.is_empty() && !wanted.contains(&directory_stem) {
-        wanted.push(directory_stem);
-    }
+    let wanted = vec![id_stem, directory_stem];
     let mut matches = Vec::new();
     visit(
         root.as_ref(),
@@ -6228,6 +6225,35 @@ mod tests {
                 String::from("packages/core/**")
             ]
         );
+    }
+
+    #[test]
+    fn section_path_inference_matches_distinct_id_and_directory_stems() {
+        let temp = TempDir::new().expect("tempdir");
+        fs::create_dir_all(temp.path().join("packages/core")).expect("id directory");
+        fs::create_dir_all(temp.path().join("crates/cli")).expect("section directory");
+
+        let paths = infer_section_paths(
+            temp.path(),
+            "@example/core",
+            Path::new("cli"),
+            Path::new("changes.d"),
+        )
+        .expect("path suggestions");
+
+        assert_eq!(paths, vec!["crates/cli/**", "packages/core/**"]);
+    }
+
+    #[test]
+    fn section_path_inference_reports_an_unreadable_root() {
+        let temp = TempDir::new().expect("tempdir");
+        let root = temp.path().join("not-a-directory");
+        fs::write(&root, "file").expect("root file");
+
+        let error = infer_section_paths(&root, "core", Path::new("core"), Path::new("changes.d"))
+            .expect_err("root read error");
+
+        assert!(matches!(error, Error::ReadFile { path, .. } if path == root));
     }
 
     #[cfg(unix)]

--- a/crates/sacho/src/commands.rs
+++ b/crates/sacho/src/commands.rs
@@ -29,7 +29,8 @@ use crate::fragment::{
 use crate::markdown::format_markdown;
 use crate::merge::{MergeDriverOptions, MergeDriverResult, merge_driver};
 use crate::released::{
-    carry_release, has_released_sections, insertion_title_span, render_released_section,
+    carry_release, has_released_sections, import_unreleased_region, insertion_title_span,
+    render_released_section,
 };
 #[cfg(test)]
 use crate::repo::MUTATION_LOCK_FILE;
@@ -482,6 +483,52 @@ pub struct CarryResult {
 
     /// Synchronization result when materialization is enabled.
     pub sync: Option<SyncResult>,
+
+    /// Non-fatal failures while removing committed transaction claims.
+    pub cleanup_warnings: Vec<MutationCleanupWarning>,
+}
+
+/// Options for importing the materialized unreleased changelog into fragments.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ImportUnreleasedOptions {
+    /// Bypass confirmation when normalization changes the materialized region.
+    pub force: bool,
+}
+
+/// Planned import of the materialized unreleased changelog.
+///
+/// Planning is read-only. If [`Self::requires_confirmation`] returns true, a
+/// caller should show [`Self::diff`] and obtain confirmation before applying.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportUnreleasedPlan {
+    /// Version inferred from the materialized heading.
+    pub inferred_version: Option<String>,
+
+    /// Fragment paths that will be created.
+    pub written_fragments: Vec<PathBuf>,
+
+    /// Normalization diff that requires confirmation, unless forced.
+    pub diff: Option<String>,
+
+    force: bool,
+    mutation: RepositoryMutationPlan,
+}
+
+impl ImportUnreleasedPlan {
+    /// Reports whether applying the plan needs caller confirmation.
+    pub fn requires_confirmation(&self) -> bool {
+        self.diff.is_some() && !self.force
+    }
+}
+
+/// Result of importing a materialized unreleased changelog.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ImportUnreleasedResult {
+    /// Fragment paths written by the import.
+    pub written_fragments: Vec<PathBuf>,
+
+    /// Version inferred from the materialized heading.
+    pub inferred_version: Option<String>,
 
     /// Non-fatal failures while removing committed transaction claims.
     pub cleanup_warnings: Vec<MutationCleanupWarning>,
@@ -1729,6 +1776,149 @@ pub fn carry(repo: &Repository, options: CarryOptions) -> Result<CarryResult> {
     Ok(CarryResult {
         written_fragments,
         sync,
+        cleanup_warnings: outcome.cleanup_warnings,
+    })
+}
+
+/// Plans importing the materialized unreleased region into fragments.
+///
+/// The plan refuses repositories that already contain Markdown fragments and
+/// validates every generated fragment before returning. No file is changed
+/// until [`apply_import_unreleased`] is called.
+pub fn plan_import_unreleased(
+    repo: &Repository,
+    options: ImportUnreleasedOptions,
+) -> Result<ImportUnreleasedPlan> {
+    if !repo.config().changelog.materialize {
+        return Err(Error::UnreleasedImportRequiresMaterialization);
+    }
+    let before_sources = snapshot_release_fragment_sources(repo)?;
+    if !before_sources.is_empty() {
+        return Err(Error::UnreleasedImportExistingFragments);
+    }
+
+    let changelog_path = repo.config().changelog.path.clone();
+    let changelog_before = read_release_file_state(repo, &changelog_path)?;
+    let changelog =
+        release_file_state_utf8(repo, &changelog_path, &changelog_before)?.ok_or_else(|| {
+            Error::ReadFile {
+                path: repo.resolve(&changelog_path),
+                source: std::io::Error::new(ErrorKind::NotFound, "changelog does not exist"),
+            }
+        })?;
+    let region = find_unreleased_region(
+        changelog,
+        repo.config().changelog.region_detection,
+        &repo.config().changelog.unreleased_heading,
+    )
+    .map_err(|source| changelog_error(changelog_path.clone(), source))?;
+    let mut imported = import_unreleased_region(repo, &changelog[region.start..region.end])?;
+    for fragment in &mut imported.fragments {
+        fragment.markdown = format_fragment_source(&fragment.markdown)
+            .map_err(|error| with_fragment_path(error, fragment.path.clone()))?;
+        parse_fragment(
+            fragment.path.clone(),
+            &fragment.markdown,
+            fragment.section.clone(),
+            &repo.config().links,
+        )
+        .map_err(|source| Error::Fragment {
+            path: fragment.path.clone(),
+            source,
+        })?;
+    }
+
+    let next_path = next_version_path(repo);
+    let next_before = read_release_file_state(repo, &next_path)?;
+    let existing_version = release_next_version(repo, &next_path, &next_before)?;
+    if let Some(actual) = &existing_version
+        && imported.version.as_ref() != Some(actual)
+    {
+        return Err(Error::UnreleasedImportNextMismatch {
+            expected: imported
+                .version
+                .clone()
+                .unwrap_or_else(|| String::from("Unreleased")),
+            actual: actual.clone(),
+        });
+    }
+    let next_after = match (&imported.version, existing_version) {
+        (Some(version), None) => ReleaseFileState::Present(format!("{version}\n")),
+        _ => next_before.clone(),
+    };
+
+    let after_sources = imported
+        .fragments
+        .iter()
+        .map(|fragment| ReleaseFragmentSource {
+            path: fragment.path.clone(),
+            contents: fragment.markdown.as_bytes().to_vec(),
+            section: fragment.section.clone(),
+        })
+        .collect::<Vec<_>>();
+    let parsed_after = parse_release_fragment_sources(repo, &after_sources)?;
+    let next_contents = release_file_state_utf8(repo, &next_path, &next_after)?;
+    let version_label = version_label_from_contents(&repo.resolve(&next_path), next_contents)?;
+    let compiled =
+        compile_parsed_fragments(repo, CompileOptions::default(), version_label, parsed_after)?;
+    let (normalized_changelog, _) =
+        synchronize_materialized_changelog(repo, changelog, &compiled, &changelog_path)?;
+    let changelog_after = ReleaseFileState::Present(normalized_changelog.clone());
+    let diff =
+        (changelog != normalized_changelog).then(|| unified_diff(changelog, &normalized_changelog));
+
+    let written_fragments = imported
+        .fragments
+        .iter()
+        .map(|fragment| fragment.path.clone())
+        .collect::<Vec<_>>();
+    let mut participants = after_sources
+        .iter()
+        .map(|source| ReleaseFileChange {
+            path: source.path.clone(),
+            before: ReleaseFileState::Missing,
+            after: release_file_state_from_bytes(source.contents.clone()),
+        })
+        .collect::<Vec<_>>();
+    participants.push(ReleaseFileChange {
+        path: next_path,
+        before: next_before,
+        after: next_after,
+    });
+    participants.push(ReleaseFileChange {
+        path: changelog_path,
+        before: changelog_before,
+        after: changelog_after,
+    });
+
+    Ok(ImportUnreleasedPlan {
+        inferred_version: imported.version,
+        written_fragments: written_fragments.clone(),
+        diff,
+        force: options.force,
+        mutation: RepositoryMutationPlan {
+            command: MutationCommand::ImportUnreleased,
+            participants,
+            fragment_paths_before: Vec::new(),
+            fragment_paths_after: written_fragments,
+        },
+    })
+}
+
+/// Applies a previously planned unreleased import transaction.
+///
+/// Every generated fragment, the next-version file, and the materialized
+/// changelog are committed together. Stale inputs and concurrent fragment
+/// additions are rejected before the first write.
+pub fn apply_import_unreleased(
+    repo: &Repository,
+    plan: ImportUnreleasedPlan,
+) -> Result<ImportUnreleasedResult> {
+    let _lock = acquire_mutation_lock(repo)?;
+    let outcome = apply_repository_mutation(repo, &plan.mutation)?;
+    Ok(ImportUnreleasedResult {
+        written_fragments: plan.written_fragments,
+        inferred_version: plan.inferred_version,
         cleanup_warnings: outcome.cleanup_warnings,
     })
 }
@@ -7575,6 +7765,167 @@ mod tests {
         .expect_err("missing version");
 
         assert!(matches!(carry_error, Error::ReleasedVersionNotFound { .. }));
+    }
+
+    #[test]
+    fn import_unreleased_plans_before_writing_and_preserves_released_bytes() {
+        let (temp, repo) = repo_with_config("");
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragment directory");
+        let released = "Version 2.3.0\n-------------\n\nReleased on July 1, 2026.\n\n -  Shipped the previous release.\n";
+        fs::write(
+            temp.path().join("CHANGES.md"),
+            format!(
+                "Version 2.4.0\n-------------\n\nTo be released.\n\n- Added import support.\n\n{released}"
+            ),
+        )
+        .expect("changelog");
+
+        let plan =
+            plan_import_unreleased(&repo, ImportUnreleasedOptions { force: false }).expect("plan");
+
+        assert!(plan.requires_confirmation());
+        assert_eq!(plan.inferred_version.as_deref(), Some("2.4.0"));
+        assert!(
+            !temp
+                .path()
+                .join("changes.d/imported-unreleased.md")
+                .exists()
+        );
+        assert!(!temp.path().join("changes.d/next").exists());
+
+        let plan = plan_import_unreleased(&repo, ImportUnreleasedOptions { force: true })
+            .expect("forced plan");
+        let result = apply_import_unreleased(&repo, plan).expect("apply");
+
+        assert_eq!(
+            result.written_fragments,
+            vec![PathBuf::from("changes.d/imported-unreleased.md")]
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("changes.d/next")).expect("next"),
+            "2.4.0\n"
+        );
+        let changelog = fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog");
+        assert!(changelog.ends_with(released));
+        assert!(
+            check(&repo, CheckOptions::default())
+                .expect("check")
+                .is_clean()
+        );
+    }
+
+    #[test]
+    fn import_unreleased_rejects_existing_fragments_without_writes() {
+        let (temp, repo) = repo_with_config("");
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragment directory");
+        fs::write(temp.path().join("changes.d/existing.md"), " -  Existing.\n")
+            .expect("existing fragment");
+        let changelog = "Unreleased\n----------\n\nTo be released.\n\n -  Added import support.\n";
+        fs::write(temp.path().join("CHANGES.md"), changelog).expect("changelog");
+
+        let error = plan_import_unreleased(&repo, ImportUnreleasedOptions { force: true })
+            .expect_err("existing fragment");
+
+        assert!(matches!(error, Error::UnreleasedImportExistingFragments));
+        assert_eq!(
+            fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog"),
+            changelog
+        );
+        assert!(
+            !temp
+                .path()
+                .join("changes.d/imported-unreleased.md")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn import_unreleased_requires_materialized_changelog() {
+        let (_temp, repo) = repo_with_config(
+            r#"
+            [changelog]
+            materialize = false
+            "#,
+        );
+
+        let error = plan_import_unreleased(&repo, ImportUnreleasedOptions { force: true })
+            .expect_err("materialized changelog required");
+
+        assert!(matches!(
+            error,
+            Error::UnreleasedImportRequiresMaterialization
+        ));
+    }
+
+    #[test]
+    fn import_unreleased_rejects_mismatched_next_version_without_writes() {
+        let (temp, repo) = repo_with_config("");
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragment directory");
+        fs::write(temp.path().join("changes.d/next"), "2.5.0\n").expect("next");
+        let changelog =
+            "Version 2.4.0\n-------------\n\nTo be released.\n\n -  Added import support.\n";
+        fs::write(temp.path().join("CHANGES.md"), changelog).expect("changelog");
+
+        let error = plan_import_unreleased(&repo, ImportUnreleasedOptions { force: true })
+            .expect_err("mismatched next version");
+
+        assert!(matches!(
+            error,
+            Error::UnreleasedImportNextMismatch {
+                expected,
+                actual
+            } if expected == "2.4.0" && actual == "2.5.0"
+        ));
+        assert_eq!(
+            fs::read_to_string(temp.path().join("changes.d/next")).expect("next"),
+            "2.5.0\n"
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog"),
+            changelog
+        );
+    }
+
+    #[test]
+    fn import_unreleased_accepts_matching_next_version() {
+        let (temp, repo) = repo_with_config("");
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragment directory");
+        fs::write(temp.path().join("changes.d/next"), "2.4.0\n").expect("next");
+        fs::write(
+            temp.path().join("CHANGES.md"),
+            "Version 2.4.0\n-------------\n\nTo be released.\n\n -  Added import support.\n",
+        )
+        .expect("changelog");
+
+        let plan = plan_import_unreleased(&repo, ImportUnreleasedOptions { force: true })
+            .expect("matching next version");
+        let result = apply_import_unreleased(&repo, plan).expect("apply");
+
+        assert_eq!(result.inferred_version.as_deref(), Some("2.4.0"));
+        assert_eq!(
+            fs::read_to_string(temp.path().join("changes.d/next")).expect("next"),
+            "2.4.0\n"
+        );
+    }
+
+    #[test]
+    fn import_unreleased_without_version_keeps_next_file_absent() {
+        let (temp, repo) = repo_with_config("");
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragment directory");
+        fs::write(
+            temp.path().join("CHANGES.md"),
+            "Unreleased\n----------\n\nTo be released.\n\n- Added import support.\n",
+        )
+        .expect("changelog");
+
+        let plan = plan_import_unreleased(&repo, ImportUnreleasedOptions { force: true })
+            .expect("version-less plan");
+
+        assert!(plan.diff.is_some());
+        assert!(!plan.requires_confirmation());
+        let result = apply_import_unreleased(&repo, plan).expect("apply");
+        assert_eq!(result.inferred_version, None);
+        assert!(!temp.path().join("changes.d/next").exists());
     }
 
     #[test]

--- a/crates/sacho/src/commands.rs
+++ b/crates/sacho/src/commands.rs
@@ -6185,6 +6185,11 @@ mod tests {
     }
 
     #[test]
+    fn init_config_escapes_remaining_ascii_control_characters() {
+        assert_eq!(toml_basic_string("\u{001f}\u{007f}"), "\"\\u001F\\u007F\"");
+    }
+
+    #[test]
     fn suggests_safe_unique_section_directories() {
         let mut used = Vec::new();
 

--- a/crates/sacho/src/commands.rs
+++ b/crates/sacho/src/commands.rs
@@ -18,7 +18,9 @@ use crate::changelog::{
     set_trailing_newline_count,
 };
 use crate::compile::{VersionLabel, compile_parsed_fragments, version_label_from_contents};
-use crate::config::{Config, ReferenceSigil, RegionDetection, UrlTemplate, VcsPreset};
+use crate::config::{
+    Config, ReferenceSigil, RegionDetection, SectionConfig, UrlTemplate, VcsPreset,
+};
 use crate::error::{Error, MutationCommand, Result};
 use crate::fragment::{
     DiscoveryWarning, Fragment, FragmentWarning, compare_fragment_paths,
@@ -74,6 +76,9 @@ pub struct InitOptions {
 
     /// Repository URL used for `links."#"` in newly generated configuration.
     pub repository_url: Option<String>,
+
+    /// Sections selected while creating new configuration.
+    pub sections: Vec<SectionConfig>,
 }
 
 /// Result of bootstrapping Sacho in a repository.
@@ -713,6 +718,130 @@ pub fn infer_repository_url(start: impl AsRef<Path>) -> Option<String> {
     let preset =
         repository_preset(&root).or_else(|| is_git_repository(&root).then_some(VcsPreset::Git))?;
     crate::repository_url::infer(&root, preset).map(|url| url.web_url)
+}
+
+/// Resolves the repository root used by [`init_repository`].
+pub fn initialization_root(start: impl AsRef<Path>) -> PathBuf {
+    init_root(start.as_ref())
+}
+
+/// Suggests a safe, unused fragment subdirectory for a section identifier.
+pub fn suggest_section_directory(id: &str, used: &[PathBuf]) -> PathBuf {
+    let stem = id.rsplit('/').next().unwrap_or(id);
+    let mut slug = String::new();
+    let mut separator = false;
+    for character in stem.chars() {
+        if character.is_ascii_alphanumeric() {
+            if separator && !slug.is_empty() {
+                slug.push('-');
+            }
+            slug.push(character.to_ascii_lowercase());
+            separator = false;
+        } else {
+            separator = true;
+        }
+    }
+    if slug.is_empty() {
+        slug.push_str("section");
+    }
+
+    for suffix in 1.. {
+        let candidate = if suffix == 1 {
+            PathBuf::from(&slug)
+        } else {
+            PathBuf::from(format!("{slug}-{suffix}"))
+        };
+        if !used.iter().any(|path| path == &candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("an unbounded numeric suffix must produce an unused path")
+}
+
+/// Finds repository directories whose basename resembles a section.
+///
+/// Returned values are repository-relative recursive glob patterns. VCS
+/// metadata, dependency caches, build output, virtual environments, symlinked
+/// directories, and the configured fragment tree are not traversed.
+pub fn infer_section_paths(
+    root: impl AsRef<Path>,
+    id: &str,
+    section_directory: &Path,
+    fragment_directory: &Path,
+) -> Result<Vec<String>> {
+    const SKIPPED_DIRECTORIES: &[&str] = &[".git", ".hg", ".jj", ".venv", "node_modules", "target"];
+
+    fn visit(
+        root: &Path,
+        relative: &Path,
+        fragment_directory: &Path,
+        wanted: &[String],
+        matches: &mut Vec<String>,
+    ) -> Result<()> {
+        let absolute = root.join(relative);
+        let entries = match fs::read_dir(&absolute) {
+            Ok(entries) => entries,
+            Err(_) if !relative.as_os_str().is_empty() => return Ok(()),
+            Err(source) => {
+                return Err(Error::ReadFile {
+                    path: absolute,
+                    source,
+                });
+            }
+        };
+        let mut entries = entries
+            .filter_map(std::result::Result::ok)
+            .collect::<Vec<_>>();
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let path = relative.join(entry.file_name());
+            if path == fragment_directory || path.starts_with(fragment_directory) {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
+            if SKIPPED_DIRECTORIES
+                .iter()
+                .any(|skipped| name.eq_ignore_ascii_case(skipped))
+            {
+                continue;
+            }
+            if wanted.iter().any(|wanted| wanted == &name)
+                && let Some(path) = path.to_str()
+            {
+                matches.push(format!("{}/**", path.replace('\\', "/")));
+            }
+            visit(root, &path, fragment_directory, wanted, matches)?;
+        }
+        Ok(())
+    }
+
+    let id_stem = id.rsplit('/').next().unwrap_or(id).to_ascii_lowercase();
+    let directory_stem = section_directory
+        .file_name()
+        .and_then(OsStr::to_str)
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let mut wanted = vec![id_stem];
+    if !directory_stem.is_empty() && !wanted.contains(&directory_stem) {
+        wanted.push(directory_stem);
+    }
+    let mut matches = Vec::new();
+    visit(
+        root.as_ref(),
+        Path::new(""),
+        fragment_directory,
+        &wanted,
+        &mut matches,
+    )?;
+    matches.sort();
+    matches.dedup();
+    Ok(matches)
 }
 
 fn load_init_config(
@@ -4794,6 +4923,10 @@ fn default_init_config(root: &Path, options: &InitOptions) -> Result<Config> {
     if let Some(materialize) = options.materialize {
         config.changelog.materialize = materialize;
     }
+    config.sections.clone_from(&options.sections);
+    for section in &config.sections {
+        compile_glob_set(&section.paths)?;
+    }
     config.vcs.preset = repository_preset(root)
         .or_else(|| is_git_repository(root).then_some(VcsPreset::Git))
         .unwrap_or(VcsPreset::None);
@@ -4814,43 +4947,91 @@ fn render_init_config(config: &Config) -> String {
     let mut output = String::new();
     output.push_str("[changelog]\n");
     output.push_str(&format!(
-        "path = {:?}\n",
-        config.changelog.path.display().to_string()
+        "path = {}\n",
+        toml_basic_string(&config.changelog.path.display().to_string())
     ));
-    output.push_str(&format!("title = {:?}\n", config.changelog.title));
     output.push_str(&format!(
-        "unreleased-heading = {:?}\n",
-        config.changelog.unreleased_heading
+        "title = {}\n",
+        toml_basic_string(&config.changelog.title)
+    ));
+    output.push_str(&format!(
+        "unreleased-heading = {}\n",
+        toml_basic_string(&config.changelog.unreleased_heading)
     ));
     output.push_str(&format!("materialize = {}\n", config.changelog.materialize));
     output.push_str(&format!(
-        "region-detection = {:?}\n\n",
-        toml_vcs_region(config.changelog.region_detection)
+        "region-detection = {}\n\n",
+        toml_basic_string(toml_vcs_region(config.changelog.region_detection))
     ));
     output.push_str("[fragments]\n");
     output.push_str(&format!(
-        "directory = {:?}\n",
-        config.fragments.directory.display().to_string()
+        "directory = {}\n",
+        toml_basic_string(&config.fragments.directory.display().to_string())
     ));
     output.push_str(&format!(
-        "next-file = {:?}\n\n",
-        config.fragments.next_file.display().to_string()
+        "next-file = {}\n\n",
+        toml_basic_string(&config.fragments.next_file.display().to_string())
     ));
     if !config.links.is_empty() {
         output.push_str("[links]\n");
         for (sigil, template) in &config.links {
-            output.push_str(&format!("{:?} = {:?}\n", sigil.as_str(), template.as_str()));
+            output.push_str(&format!(
+                "{} = {}\n",
+                toml_basic_string(sigil.as_str()),
+                toml_basic_string(template.as_str())
+            ));
         }
         output.push('\n');
     }
     output.push_str("[vcs]\n");
     output.push_str(&format!(
-        "preset = {:?}\n\n",
-        toml_vcs_preset(config.vcs.preset)
+        "preset = {}\n\n",
+        toml_basic_string(toml_vcs_preset(config.vcs.preset))
     ));
     output.push_str("[check]\n");
     output.push_str("paths = []\n");
+    for section in &config.sections {
+        output.push_str("\n[[sections]]\n");
+        output.push_str(&format!("id = {}\n", toml_basic_string(&section.id)));
+        output.push_str(&format!(
+            "directory = {}\n",
+            toml_basic_string(&section.directory.display().to_string())
+        ));
+        output.push_str(&format!("paths = {}\n", toml_string_array(&section.paths)));
+    }
     output
+}
+
+fn toml_basic_string(value: &str) -> String {
+    let mut output = String::from("\"");
+    for character in value.chars() {
+        match character {
+            '\"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            '\u{0008}' => output.push_str("\\b"),
+            '\t' => output.push_str("\\t"),
+            '\n' => output.push_str("\\n"),
+            '\u{000c}' => output.push_str("\\f"),
+            '\r' => output.push_str("\\r"),
+            control if control <= '\u{001f}' || control == '\u{007f}' => {
+                output.push_str(&format!("\\u{:04X}", control as u32));
+            }
+            character => output.push(character),
+        }
+    }
+    output.push('\"');
+    output
+}
+
+fn toml_string_array(values: &[String]) -> String {
+    format!(
+        "[{}]",
+        values
+            .iter()
+            .map(|value| toml_basic_string(value))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 fn validate_init_changelog_path(
@@ -5785,12 +5966,102 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: Some(String::from("   ")),
+                sections: Vec::new(),
             },
         )
         .expect("blank repository URL");
 
         assert!(config.links.is_empty());
         assert!(!render_init_config(&config).contains("[links]"));
+    }
+
+    #[test]
+    fn init_config_renders_selected_sections() {
+        let options = InitOptions {
+            sections: vec![SectionConfig {
+                id: String::from("👨‍👩‍👧 core"),
+                directory: PathBuf::from("core"),
+                paths: vec![String::from("packages/core/**")],
+            }],
+            ..InitOptions::default()
+        };
+        let config = default_init_config(Path::new("project"), &options).expect("init config");
+        let rendered = render_init_config(&config);
+        let reparsed = Config::parse(&rendered).expect("rendered config");
+
+        assert_eq!(reparsed.sections, options.sections);
+        assert!(rendered.contains("[[sections]]"));
+        assert!(rendered.contains("id = \"👨‍👩‍👧 core\""));
+        assert!(!rendered.contains("\\u{"));
+        assert!(rendered.contains("directory = \"core\""));
+        assert!(rendered.contains("paths = [\"packages/core/**\"]"));
+    }
+
+    #[test]
+    fn suggests_safe_unique_section_directories() {
+        let mut used = Vec::new();
+
+        let first = suggest_section_directory("@example/Core tools", &used);
+        used.push(first.clone());
+        let second = suggest_section_directory("core-tools", &used);
+
+        assert_eq!(first, PathBuf::from("core-tools"));
+        assert_eq!(second, PathBuf::from("core-tools-2"));
+    }
+
+    #[test]
+    fn infers_section_paths_by_directory_name_and_skips_generated_trees() {
+        let temp = TempDir::new().expect("tempdir");
+        for path in [
+            "packages/core",
+            "examples/core",
+            "target/core",
+            "node_modules/core",
+            ".git/core",
+            "changes.d/core",
+        ] {
+            fs::create_dir_all(temp.path().join(path)).expect("directory");
+        }
+
+        let paths = infer_section_paths(
+            temp.path(),
+            "@example/core",
+            Path::new("core"),
+            Path::new("changes.d"),
+        )
+        .expect("path suggestions");
+
+        assert_eq!(
+            paths,
+            vec![
+                String::from("examples/core/**"),
+                String::from("packages/core/**")
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn section_path_inference_skips_unreadable_subdirectories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("tempdir");
+        fs::create_dir_all(temp.path().join("packages/core")).expect("package directory");
+        let unreadable = temp.path().join("private");
+        fs::create_dir(&unreadable).expect("private directory");
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000))
+            .expect("remove permissions");
+
+        let result = infer_section_paths(
+            temp.path(),
+            "core",
+            Path::new("core"),
+            Path::new("changes.d"),
+        );
+
+        fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o700))
+            .expect("restore permissions");
+        assert_eq!(result.expect("best-effort scan"), vec!["packages/core/**"]);
     }
 
     #[test]
@@ -6247,6 +6518,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect("init");
@@ -6278,6 +6550,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect_err("concurrent init lock");
@@ -6302,6 +6575,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect_err("mutation lock changelog");
@@ -6332,6 +6606,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect_err("Git mutation lock changelog");
@@ -6361,6 +6636,7 @@ mod tests {
                     install_hook: false,
                     append_existing_hook: false,
                     repository_url: None,
+                    sections: Vec::new(),
                 },
             )
             .expect_err("future VCS lock parent");
@@ -6392,6 +6668,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect_err("inactive Git lock parent");
@@ -6436,6 +6713,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect("init");
@@ -6465,6 +6743,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect_err("configuration changelog alias");
@@ -6497,6 +6776,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect_err("configuration changelog alias");
@@ -6566,6 +6846,7 @@ mod tests {
                 install_hook: true,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect("init");
@@ -6593,6 +6874,7 @@ mod tests {
                 install_hook: true,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect("init");
@@ -6615,6 +6897,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect("init");
@@ -6643,6 +6926,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect("init");
@@ -6676,6 +6960,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect_err("fragment path conflict");
@@ -6699,6 +6984,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         )
         .expect_err("changelog path conflict");
@@ -10122,6 +10408,7 @@ mod tests {
                 install_hook: false,
                 append_existing_hook: false,
                 repository_url: None,
+                sections: Vec::new(),
             },
         ));
         assert_mutation_locked(add_fragment(

--- a/crates/sacho/src/error.rs
+++ b/crates/sacho/src/error.rs
@@ -14,6 +14,9 @@ pub enum MutationCommand {
 
     /// The `carry` command.
     Carry,
+
+    /// The `import-unreleased` command.
+    ImportUnreleased,
 }
 
 impl std::fmt::Display for MutationCommand {
@@ -22,6 +25,7 @@ impl std::fmt::Display for MutationCommand {
             Self::Next => "next",
             Self::Format => "fmt",
             Self::Carry => "carry",
+            Self::ImportUnreleased => "import-unreleased",
         })
     }
 }
@@ -48,6 +52,37 @@ pub enum Error {
 
         /// Reason the executable cannot be used.
         reason: &'static str,
+    },
+
+    /// Existing unreleased Markdown cannot be represented as Sacho fragments.
+    #[snafu(display("cannot import unreleased changelog: {message}"))]
+    UnreleasedImportIncompatible {
+        /// Explanation of the incompatible Markdown structure.
+        message: String,
+    },
+
+    /// The unreleased region contains no list items to import.
+    #[snafu(display("cannot import unreleased changelog because it contains no entries"))]
+    UnreleasedImportEmpty,
+
+    /// Importing requires a materialized changelog region.
+    #[snafu(display("`sacho import-unreleased` requires changelog.materialize = true"))]
+    UnreleasedImportRequiresMaterialization,
+
+    /// Existing fragments make the import target ambiguous.
+    #[snafu(display("cannot import unreleased changelog while Markdown fragments already exist"))]
+    UnreleasedImportExistingFragments,
+
+    /// The current next-version file disagrees with the changelog heading.
+    #[snafu(display(
+        "cannot import unreleased changelog because its heading implies {expected}, but the next-version file contains {actual}"
+    ))]
+    UnreleasedImportNextMismatch {
+        /// Version implied by the materialized heading.
+        expected: String,
+
+        /// Version found in the next-version file.
+        actual: String,
     },
 
     /// A file could not be read.

--- a/crates/sacho/src/released.rs
+++ b/crates/sacho/src/released.rs
@@ -36,6 +36,16 @@ pub struct CarriedFragment {
     pub markdown: String,
 }
 
+/// Fragments decompiled from the current unreleased changelog region.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportedUnreleased {
+    /// Version inferred from a `Version X` heading, or `None` for `Unreleased`.
+    pub version: Option<String>,
+
+    /// Fragment outputs to write.
+    pub fragments: Vec<CarriedFragment>,
+}
+
 /// A possible Sacho section found in an existing changelog.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangelogSectionCandidate {
@@ -202,6 +212,152 @@ pub fn carry_release(repo: &Repository, changelog: &str, version: &str) -> Resul
         version: version.to_owned(),
         fragments,
     })
+}
+
+/// Parses a materialized unreleased region into deterministic fragments.
+///
+/// Only the version heading, configured unreleased date line, direct
+/// level-three section headings, and top-level unordered lists are accepted.
+/// This conservative shape prevents an import from silently dropping hand
+/// edits that fragments cannot represent.
+pub fn import_unreleased_region(repo: &Repository, region: &str) -> Result<ImportedUnreleased> {
+    let arena = Arena::new();
+    let root = parse_document(&arena, region, &comrak_options());
+    let line_starts = line_starts(region);
+    let references = reference_definitions(region);
+    let mut version = None;
+    let mut saw_heading = false;
+    let mut current_section = None;
+    let mut entries = Vec::new();
+
+    for child in root.children() {
+        let value = child.data().value.clone();
+        match value {
+            NodeValue::Heading(heading) if heading.level <= 2 && !saw_heading => {
+                let heading = plain_text(child).trim().to_owned();
+                if heading == "Unreleased" {
+                    version = None;
+                } else if let Some(inferred) = heading.strip_prefix("Version ")
+                    && !inferred.trim().is_empty()
+                {
+                    version = Some(inferred.trim().to_owned());
+                } else {
+                    return Err(import_incompatible(
+                        "expected `Unreleased` or `Version X` heading",
+                    ));
+                }
+                saw_heading = true;
+            }
+            NodeValue::Heading(heading)
+                if heading.level == 3 && !repo.config().sections.is_empty() =>
+            {
+                if !saw_heading {
+                    return Err(import_incompatible(
+                        "section heading appears before version heading",
+                    ));
+                }
+                let section = plain_text(child).trim().to_owned();
+                ensure_known_section(repo, &section)?;
+                current_section = Some(section);
+            }
+            NodeValue::Heading(heading) if heading.level == 3 => {
+                if !saw_heading {
+                    return Err(import_incompatible(
+                        "heading appears before version heading",
+                    ));
+                }
+                return Err(import_incompatible(
+                    "section headings are not supported without configured sections",
+                ));
+            }
+            NodeValue::Paragraph
+                if saw_heading
+                    && plain_text(child).trim() == repo.config().changelog.unreleased_heading => {}
+            NodeValue::List(list) if saw_heading && list.list_type == ListType::Bullet => {
+                if !repo.config().sections.is_empty() && current_section.is_none() {
+                    return Err(Error::ReleasedEntryWithoutSection);
+                }
+                for item in child.children() {
+                    let source = slice_item_sourcepos(region, &line_starts, item.data().sourcepos)
+                        .unwrap_or_default();
+                    entries.push(ParsedEntry {
+                        section: current_section.clone(),
+                        item_markdown: fold_item_references(
+                            source,
+                            item,
+                            &line_starts,
+                            &references,
+                        ),
+                    });
+                }
+            }
+            _ => {
+                return Err(import_incompatible(
+                    "only the version heading, unreleased date line, section headings, and unordered lists are supported",
+                ));
+            }
+        }
+    }
+    if !saw_heading {
+        return Err(import_incompatible("unreleased version heading is missing"));
+    }
+    if entries.is_empty() {
+        return Err(Error::UnreleasedImportEmpty);
+    }
+
+    Ok(ImportedUnreleased {
+        version,
+        fragments: fragments_from_entries(repo, entries, "imported-unreleased.md")?,
+    })
+}
+
+fn import_incompatible(message: &str) -> Error {
+    Error::UnreleasedImportIncompatible {
+        message: message.to_owned(),
+    }
+}
+
+fn fragments_from_entries(
+    repo: &Repository,
+    entries: Vec<ParsedEntry>,
+    filename: &str,
+) -> Result<Vec<CarriedFragment>> {
+    let mut grouped = BTreeMap::<Option<String>, Vec<String>>::new();
+    for entry in entries {
+        grouped
+            .entry(entry.section)
+            .or_default()
+            .push(entry.item_markdown);
+    }
+    let mut fragments = Vec::new();
+    if repo.config().sections.is_empty() {
+        let items = grouped.remove(&None).unwrap_or_default();
+        if !items.is_empty() {
+            fragments.push(CarriedFragment {
+                section: None,
+                path: repo.config().fragments.directory.join(filename),
+                markdown: fragment_markdown(items),
+            });
+        }
+    } else {
+        for section in &repo.config().sections {
+            let section_id = Some(section.id.clone());
+            let Some(items) = grouped.remove(&section_id) else {
+                continue;
+            };
+            fragments.push(CarriedFragment {
+                section: section_id,
+                path: repo
+                    .config()
+                    .fragments
+                    .directory
+                    .join(&section.directory)
+                    .join(filename),
+                markdown: fragment_markdown(items),
+            });
+        }
+    }
+    Ok(fragments)
 }
 
 /// Finds a released version section in changelog Markdown.
@@ -1182,6 +1338,84 @@ Released on July 7, 2026.
             carried.fragments[0].markdown,
             " -  Fixed carry.\n -  Added carry.\n"
         );
+    }
+
+    #[test]
+    fn imports_unreleased_entries_into_stable_fragment_names() {
+        let (_temp, repo) = repo_with_config(
+            r#"
+            [[sections]]
+            id = "core"
+            directory = "core"
+
+            [[sections]]
+            id = "cli"
+            directory = "cli"
+            "#,
+        );
+        let region = "\
+Version 2.4.0
+-------------
+
+To be released.
+
+### core
+
+ -  Added core support.
+
+### cli
+
+ -  Added a command.
+";
+
+        let imported = import_unreleased_region(&repo, region).expect("import");
+
+        assert_eq!(imported.version.as_deref(), Some("2.4.0"));
+        assert_eq!(
+            imported
+                .fragments
+                .iter()
+                .map(|fragment| fragment.path.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                PathBuf::from("changes.d/core/imported-unreleased.md"),
+                PathBuf::from("changes.d/cli/imported-unreleased.md"),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_top_level_prose_during_unreleased_import() {
+        let (_temp, repo) = repo_with_config("");
+        let error = import_unreleased_region(
+            &repo,
+            "Unreleased\n----------\n\nTo be released.\n\nHand-written note.\n",
+        )
+        .expect_err("top-level prose");
+
+        assert!(matches!(error, Error::UnreleasedImportIncompatible { .. }));
+    }
+
+    #[test]
+    fn rejects_section_headings_without_configured_sections_during_import() {
+        let (_temp, repo) = repo_with_config("");
+        let error = import_unreleased_region(
+            &repo,
+            "Unreleased\n----------\n\nTo be released.\n\n### Fixed\n\n -  Fixed a bug.\n",
+        )
+        .expect_err("unrepresentable section heading");
+
+        assert!(matches!(error, Error::UnreleasedImportIncompatible { .. }));
+        assert!(error.to_string().contains("configured sections"));
+    }
+
+    #[test]
+    fn rejects_empty_unreleased_import() {
+        let (_temp, repo) = repo_with_config("");
+        let error = import_unreleased_region(&repo, "Unreleased\n----------\n\nTo be released.\n")
+            .expect_err("empty import");
+
+        assert!(matches!(error, Error::UnreleasedImportEmpty));
     }
 
     #[test]

--- a/crates/sacho/src/released.rs
+++ b/crates/sacho/src/released.rs
@@ -36,6 +36,19 @@ pub struct CarriedFragment {
     pub markdown: String,
 }
 
+/// A possible Sacho section found in an existing changelog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangelogSectionCandidate {
+    /// Text of the direct level-three heading.
+    pub id: String,
+
+    /// Number of matching level-three heading occurrences.
+    pub occurrences: usize,
+
+    /// Whether the heading occurs in the current unreleased region.
+    pub appears_in_unreleased: bool,
+}
+
 #[derive(Debug, Clone)]
 struct TargetSection<'a> {
     body: &'a str,
@@ -53,6 +66,96 @@ struct ParsedEntry {
 struct ReferenceDefinition {
     label: String,
     url: String,
+}
+
+#[derive(Debug, Clone)]
+struct SectionCandidateRegion {
+    unreleased: bool,
+    sections: Vec<String>,
+}
+
+/// Finds direct level-three headings inside changelog version regions.
+///
+/// The first level-one or Setext heading is ignored when it matches
+/// `document_title` so a title such as `Version history` does not open a
+/// version region.
+///
+/// Candidates from a region containing `unreleased_heading` are ordered before
+/// candidates found only in released history. Within each group, candidates
+/// retain their first-appearance order. Callers must still ask a person which
+/// headings represent stable repository sections because change categories
+/// such as `Added` have the same Markdown shape.
+pub fn discover_section_candidates(
+    changelog: &str,
+    document_title: &str,
+    unreleased_heading: &str,
+) -> Vec<ChangelogSectionCandidate> {
+    let arena = Arena::new();
+    let root = parse_document(&arena, changelog, &comrak_options());
+    let mut regions = Vec::<SectionCandidateRegion>::new();
+    let mut current = None;
+    let mut first_heading = true;
+
+    for child in root.children() {
+        match &child.data().value {
+            NodeValue::Heading(heading) => {
+                let text = plain_text(child).trim().to_owned();
+                if first_heading && (heading.level == 1 || heading.setext) && text == document_title
+                {
+                    first_heading = false;
+                    continue;
+                }
+                first_heading = false;
+                if heading.level <= 2 && (text == "Unreleased" || is_version_heading_text(&text)) {
+                    regions.push(SectionCandidateRegion {
+                        unreleased: text == "Unreleased",
+                        sections: Vec::new(),
+                    });
+                    current = Some(regions.len() - 1);
+                } else if heading.level == 3
+                    && let Some(index) = current
+                    && !text.is_empty()
+                {
+                    regions[index].sections.push(text);
+                }
+            }
+            NodeValue::Paragraph
+                if current.is_some() && plain_text(child).trim() == unreleased_heading =>
+            {
+                regions[current.expect("checked above")].unreleased = true;
+            }
+            _ => {}
+        }
+    }
+
+    let mut candidates = Vec::<ChangelogSectionCandidate>::new();
+    for unreleased in [true, false] {
+        for region in regions
+            .iter()
+            .filter(|region| region.unreleased == unreleased)
+        {
+            for id in &region.sections {
+                if candidates.iter().any(|candidate| candidate.id == *id) {
+                    continue;
+                }
+                let occurrences = regions
+                    .iter()
+                    .flat_map(|region| &region.sections)
+                    .filter(|section| *section == id)
+                    .count();
+                candidates.push(ChangelogSectionCandidate {
+                    id: id.clone(),
+                    occurrences,
+                    appears_in_unreleased: regions
+                        .iter()
+                        .filter(|region| region.unreleased)
+                        .flat_map(|region| &region.sections)
+                        .any(|section| section == id),
+                });
+            }
+        }
+    }
+    candidates
 }
 
 /// Parses a released version section and returns deterministic carry fragments.
@@ -821,6 +924,136 @@ mod tests {
         fs::write(temp.path().join("sacho.toml"), config).expect("config");
         let repo = Repository::from_root(temp.path()).expect("repo");
         (temp, repo)
+    }
+
+    #[test]
+    fn discovers_section_candidates_with_unreleased_entries_first() {
+        let changelog = "\
+Project changes
+===============
+
+Version 2.0.0
+-------------
+
+To be released.
+
+### core
+
+ -  Added a core feature.
+
+### Added
+
+ -  Added something else.
+
+### Version 9.9.9
+
+ -  This is a section heading, not a version region.
+
+Version 1.0.0
+-------------
+
+Released on July 1, 2026.
+
+### cli
+
+ -  Added a command.
+
+### core
+
+ -  Fixed the core.
+
+ -  A nested heading:
+
+    ### ignored
+
+```markdown
+### also ignored
+```
+";
+
+        let candidates =
+            discover_section_candidates(changelog, "Project changes", "To be released.");
+
+        assert_eq!(
+            candidates,
+            vec![
+                ChangelogSectionCandidate {
+                    id: String::from("core"),
+                    occurrences: 2,
+                    appears_in_unreleased: true,
+                },
+                ChangelogSectionCandidate {
+                    id: String::from("Added"),
+                    occurrences: 1,
+                    appears_in_unreleased: true,
+                },
+                ChangelogSectionCandidate {
+                    id: String::from("Version 9.9.9"),
+                    occurrences: 1,
+                    appears_in_unreleased: true,
+                },
+                ChangelogSectionCandidate {
+                    id: String::from("cli"),
+                    occurrences: 1,
+                    appears_in_unreleased: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn discovers_candidates_below_a_literal_unreleased_heading() {
+        let candidates = discover_section_candidates(
+            "## Unreleased\n\n### server\n\n -  Added a server.\n",
+            "Project changes",
+            "To be released.",
+        );
+
+        assert_eq!(
+            candidates,
+            vec![ChangelogSectionCandidate {
+                id: String::from("server"),
+                occurrences: 1,
+                appears_in_unreleased: true,
+            }]
+        );
+    }
+
+    #[test]
+    fn ignores_a_version_shaped_document_title_and_its_preamble() {
+        for underline in ["===============", "---------------"] {
+            let changelog = format!(
+                "\
+Version history
+{underline}
+
+### Notation
+
+This heading describes the document.
+
+Version 1.0.0
+-------------
+
+Released on July 1, 2026.
+
+### core
+
+ -  Added core.
+"
+            );
+
+            let candidates =
+                discover_section_candidates(&changelog, "Version history", "To be released.");
+
+            assert_eq!(
+                candidates,
+                vec![ChangelogSectionCandidate {
+                    id: String::from("core"),
+                    occurrences: 1,
+                    appears_in_unreleased: false,
+                }]
+            );
+        }
     }
 
     #[test]

--- a/crates/sacho/src/released.rs
+++ b/crates/sacho/src/released.rs
@@ -1439,6 +1439,39 @@ To be released.
     }
 
     #[test]
+    fn rejects_a_level_three_unreleased_region_heading() {
+        let (_temp, repo) = repo_with_config("");
+        let error = import_unreleased_region(&repo, "### Unreleased\n\n -  Added a feature.\n")
+            .expect_err("level-three region heading");
+
+        assert!(matches!(error, Error::UnreleasedImportIncompatible { .. }));
+    }
+
+    #[test]
+    fn rejects_a_second_version_heading_during_import() {
+        let (_temp, repo) = repo_with_config("");
+        let error = import_unreleased_region(
+            &repo,
+            "Unreleased\n----------\n\nTo be released.\n\n -  Added one feature.\n\n## Unreleased\n\n -  Added another feature.\n",
+        )
+        .expect_err("second version heading");
+
+        assert!(matches!(error, Error::UnreleasedImportIncompatible { .. }));
+    }
+
+    #[test]
+    fn rejects_ordered_lists_during_import() {
+        let (_temp, repo) = repo_with_config("");
+        let error = import_unreleased_region(
+            &repo,
+            "Unreleased\n----------\n\nTo be released.\n\n 1. Added a feature.\n",
+        )
+        .expect_err("ordered list");
+
+        assert!(matches!(error, Error::UnreleasedImportIncompatible { .. }));
+    }
+
+    #[test]
     fn rejects_empty_unreleased_import() {
         let (_temp, repo) = repo_with_config("");
         let error = import_unreleased_region(&repo, "Unreleased\n----------\n\nTo be released.\n")

--- a/crates/sacho/src/released.rs
+++ b/crates/sacho/src/released.rs
@@ -1213,6 +1213,35 @@ Released on July 1, 2026.
     }
 
     #[test]
+    fn ignores_an_exact_version_shaped_document_title() {
+        let candidates = discover_section_candidates(
+            "# Version 9.9.9\n\n### Notation\n\nDocument notation.\n",
+            "Version 9.9.9",
+            "To be released.",
+        );
+
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn keeps_a_version_shaped_h1_that_is_not_the_document_title() {
+        let candidates = discover_section_candidates(
+            "# Version 9.9.9\n\n### core\n\n -  Added core.\n",
+            "Project changes",
+            "To be released.",
+        );
+
+        assert_eq!(
+            candidates,
+            vec![ChangelogSectionCandidate {
+                id: String::from("core"),
+                occurrences: 1,
+                appears_in_unreleased: false,
+            }]
+        );
+    }
+
+    #[test]
     fn finds_setext_version_target() {
         let (_temp, repo) = repo_with_config(
             r##"

--- a/crates/sacho/tests/cli.rs
+++ b/crates/sacho/tests/cli.rs
@@ -31,6 +31,7 @@ fn repository_commands_reject_an_external_configured_path_without_touching_it() 
         &["sync", "--force"],
         &["release", "1.2.0", "--date", "2026-07-15"],
         &["carry", "1.1.0"],
+        &["import-unreleased", "--force"],
     ];
 
     for args in invocations {
@@ -1416,6 +1417,93 @@ fn sync_without_force_exits_two_and_leaves_changelog_unchanged() {
 }
 
 #[test]
+fn import_unreleased_requires_force_non_interactively_then_imports() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(temp.path().join("sacho.toml"), "").expect("config");
+    std::fs::create_dir(temp.path().join("changes.d")).expect("fragment directory");
+    let changelog = "Version 2.4.0\n-------------\n\nTo be released.\n\n- Added import support.\n\nVersion 2.3.0\n-------------\n\nReleased on July 1, 2026.\n\n -  Previous release.\n";
+    std::fs::write(temp.path().join("CHANGES.md"), changelog).expect("changelog");
+
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+    command
+        .current_dir(temp.path())
+        .arg("import-unreleased")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "rerun with `sacho import-unreleased --force`",
+        ));
+
+    assert!(
+        !temp
+            .path()
+            .join("changes.d/imported-unreleased.md")
+            .exists()
+    );
+    assert!(!temp.path().join("changes.d/next").exists());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("CHANGES.md")).expect("unchanged changelog"),
+        changelog
+    );
+
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+    command
+        .current_dir(temp.path())
+        .args(["import-unreleased", "--force"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("changes.d/imported-unreleased.md"));
+
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("changes.d/next")).expect("next"),
+        "2.4.0\n"
+    );
+    let mut check = Command::cargo_bin("sacho").expect("binary");
+    check
+        .current_dir(temp.path())
+        .arg("check")
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_unreleased_in_terminal_applies_after_yes_confirmation() {
+    let temp = import_unreleased_confirmation_repository();
+
+    let (success, output) = run_in_terminal(temp.path(), &["import-unreleased"], "yes\n");
+
+    assert!(success, "{output}");
+    assert!(output.contains("normalize the materialized"), "{output}");
+    assert!(output.contains("[y/N]"), "{output}");
+    assert!(
+        temp.path()
+            .join("changes.d/imported-unreleased.md")
+            .exists()
+    );
+}
+
+#[test]
+fn import_unreleased_in_terminal_keeps_repository_after_default_no() {
+    let temp = import_unreleased_confirmation_repository();
+    let original = std::fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog");
+
+    let (success, output) = run_in_terminal(temp.path(), &["import-unreleased"], "\n");
+
+    assert!(!success, "{output}");
+    assert!(output.contains("cancelled"), "{output}");
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog"),
+        original
+    );
+    assert!(
+        !temp
+            .path()
+            .join("changes.d/imported-unreleased.md")
+            .exists()
+    );
+}
+
+#[test]
 fn sync_in_terminal_applies_after_yes_confirmation() {
     let temp = sync_confirmation_repository();
 
@@ -1691,6 +1779,18 @@ fn sync_confirmation_repository() -> tempfile::TempDir {
     std::fs::write(
         temp.path().join("CHANGES.md"),
         "Unreleased\n----------\n\nTo be released.\n\nHand-edited note.\n",
+    )
+    .expect("changelog");
+    temp
+}
+
+fn import_unreleased_confirmation_repository() -> tempfile::TempDir {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(temp.path().join("sacho.toml"), "").expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    std::fs::write(
+        temp.path().join("CHANGES.md"),
+        "Unreleased\n----------\n\nTo be released.\n\n- Added import support.\n",
     )
     .expect("changelog");
     temp

--- a/crates/sacho/tests/cli.rs
+++ b/crates/sacho/tests/cli.rs
@@ -384,6 +384,38 @@ fn init_interactive_infers_a_git_worktree_remote() {
 }
 
 #[test]
+fn init_interactive_configures_selected_changelog_sections() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    git(temp.path(), ["init"]);
+    std::fs::create_dir_all(temp.path().join("packages/core")).expect("package directory");
+    std::fs::write(
+        temp.path().join("CHANGES.md"),
+        "Project changes\n===============\n\nVersion 2.0.0\n-------------\n\nTo be released.\n\n### core\n\n -  Added core.\n\nVersion 1.0.0\n-------------\n\nReleased on July 1, 2026.\n\n### core\n\n -  Shipped core.\n",
+    )
+    .expect("changelog");
+
+    let (success, output) = run_in_terminal(temp.path(), &["init"], "\n\n\n9\n1\n\n\n\n\n");
+
+    assert!(success, "{output}");
+    assert!(
+        output.contains("section number 9 is outside 1..=1"),
+        "{output}"
+    );
+    assert!(
+        output.contains("1. core (2 occurrences, unreleased)"),
+        "{output}"
+    );
+    let config = std::fs::read_to_string(temp.path().join("sacho.toml")).expect("configuration");
+    assert!(config.contains("[[sections]]"), "{config}");
+    assert!(config.contains("id = \"core\""), "{config}");
+    assert!(config.contains("directory = \"core\""), "{config}");
+    assert!(
+        config.contains("paths = [\"packages/core/**\"]"),
+        "{config}"
+    );
+}
+
+#[test]
 fn init_discovers_a_markerless_git_worktree_from_the_environment() {
     let temp = tempfile::TempDir::new().expect("tempdir");
     let metadata_worktree = temp.path().join("metadata-worktree");

--- a/docs/concepts/changelog-lifecycle.md
+++ b/docs/concepts/changelog-lifecycle.md
@@ -43,6 +43,7 @@ Fragments remain the source of truth. Do not edit this region by hand.
 Several commands keep it current:
 
  -  `sacho add` creates a fragment and refreshes the region.
+ -  `sacho import-unreleased` adopts existing entries and normalizes the region.
  -  `sacho next` changes the version and refreshes the heading.
  -  `sacho fmt` formats every fragment and refreshes the region.
  -  `sacho sync` refreshes only the generated region.
@@ -59,6 +60,26 @@ with an empty body while closed.
 
 Set `materialize = false` when the repository should keep only released history
 in *CHANGES.md*. `sacho preview` still compiles the unreleased region on demand.
+
+
+Importing an existing region
+----------------------------
+
+An existing project may already have user-written entries in its current
+unreleased region when Sacho is initialized. Run `sacho import-unreleased`
+before adding fragments. It parses only that region, writes deterministic
+*imported-unreleased.md* fragments, and compiles them back into the same region.
+Released sections remain untouched.
+
+Configured level-three headings select section directories. Without configured
+sections, level-three headings are rejected because flattening them would lose
+structure. Top-level prose, ordered lists, and other unsupported blocks are
+also rejected. These checks still apply with `--force`.
+
+The import shows a normalization diff and asks for confirmation when running in
+a terminal. Noninteractive callers must review the diff and rerun with
+`--force`. A version in a `Version X` heading becomes the next-version value;
+an `Unreleased` heading does not set a next-version value.
 
 
 Fragments-only repositories

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -80,13 +80,38 @@ sacho init
 Sacho creates *sacho.toml*, *changes.d/*, and *CHANGES.md*. In a Git repository
 it also registers merge drivers in *.gitattributes* and the local Git config.
 Interactive setup can infer issue links from the repository remote and offer to
-install commit hooks.
+install commit hooks. When *CHANGES.md* already exists, it can also offer
+level-three headings found across the changelog as section ids, then suggest
+fragment directories and source path globs for the selected sections.
 
 Use `sacho init --interactive` to ask the setup questions even when automatic
 detection would otherwise be enough. For scripts, `--no-interactive` prevents
 prompts.
 
-Set the version you are preparing:
+
+Import existing unreleased entries
+----------------------------------
+
+Skip this step when the changelog has no current unreleased entries. Otherwise,
+run the import before creating any fragments:
+
+~~~~ sh
+sacho import-unreleased
+~~~~
+
+The command reads the current `Unreleased` or `Version X` region, creates
+*changes.d/imported-unreleased.md*, and leaves released history unchanged.
+Repositories configured with sections receive one file in each populated
+section directory. A `Version X` heading also becomes the next-version value,
+so do not run `sacho next` separately unless the heading is `Unreleased`.
+
+Sacho shows a diff when compiling the imported fragments would normalize the
+region. Confirm it in a terminal, or use `--force` after reviewing the same
+change in a noninteractive workflow. `--force` does not permit existing
+Markdown fragments or top-level prose, headings, and lists that fragments
+cannot represent.
+
+If the import did not infer a version, set the version you are preparing:
 
 ~~~~ sh
 sacho next 1.2.0

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -15,6 +15,12 @@ sacho init [OPTIONS]
 Creates the configuration, fragment directory, initial changelog, and
 version-control integration that do not already exist.
 
+During first-time interactive setup with an existing changelog, Sacho offers
+level-three headings found across the changelog as section candidates. For each
+selected candidate, it suggests a fragment directory and source path globs. The
+prompts remain editable, and selecting no candidates leaves `[[sections]]`
+absent.
+
 | Option                            | Meaning                                                          |
 | --------------------------------- | ---------------------------------------------------------------- |
 | `--interactive`                   | Ask setup questions even when automatic detection is sufficient. |
@@ -176,6 +182,27 @@ sacho carry <VERSION>
 Turns the entries from one released section back into editable fragments named
 *carried-from-VERSION.md*. Sectioned releases produce one fragment in each
 populated section. Existing carried fragment destinations are replaced.
+
+
+`sacho import-unreleased`
+-------------------------
+
+~~~~ text
+sacho import-unreleased [--force]
+~~~~
+
+Converts the materialized `Unreleased` or `Version X` region into deterministic
+*imported-unreleased.md* fragments. A sectioned repository receives one file
+per populated configured section. The `X` from a `Version X` heading is also
+written to the next-version file, which must be absent, empty, or already equal
+to `X`.
+
+The repository must use `materialize = true` and contain no Markdown fragments.
+Sacho rejects top-level content that fragments cannot represent and never
+changes released history. If normalized fragment output changes the unreleased
+region, an interactive invocation shows the diff and asks for confirmation. A
+noninteractive invocation exits with status 2; `--force` applies the reviewed
+normalization without a prompt. It does not bypass safety errors.
 
 
 `sacho merge-driver`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,6 +31,25 @@ Start with the smallest valid form:
 Then run `sacho fmt` and `sacho check`.
 
 
+`import-unreleased` refuses the changelog
+-----------------------------------------
+
+Import is available only for a materialized changelog before any Markdown
+fragments exist. If fragments already exist, decide whether they or the current
+unreleased region are the source of truth instead of merging both implicitly.
+
+The region may contain its version heading, the configured unreleased date
+line, configured level-three section headings, and top-level unordered lists.
+Move other top-level prose into list items before importing. Configure a section
+for each level-three heading you need to preserve, or remove the headings when
+the repository intentionally uses one unsectioned fragment stream.
+
+When *changes.d/next* already has a value, it must match `X` in the imported
+`Version X` heading. Resolve the disagreement explicitly, then rerun the
+command. `--force` confirms normalization only and does not bypass these
+checks.
+
+
 `missing changelog fragment`
 ----------------------------
 

--- a/skills/sacho/SKILL.md
+++ b/skills/sacho/SKILL.md
@@ -89,13 +89,18 @@ Adopting Sacho in a project
 Run `sacho init` from the repository root. It creates `sacho.toml`,
 `changes.d/`, and `CHANGES.md`, and in a Git repository registers the merge
 drivers. Interactive setup infers issue-link templates from the remote and can
-install commit hooks; `sacho init --interactive` forces the questions and
-`--no-interactive` suppresses them.
+install commit hooks. When an existing changelog is present, it also offers
+level-three headings found across the changelog as section candidates and
+suggests directories and source path globs. `sacho init --interactive` forces
+the questions and `--no-interactive` suppresses them.
 
-Adoption needs no migration. Sacho never rewrites existing released sections, so
-leave the old `CHANGES.md` history exactly as it is and start using fragments
-for the next version. Set that version with `sacho next 1.2.0` so the unreleased
-heading and `release` know what is being prepared.
+Leave old released sections exactly as they are. If the current `Unreleased` or
+`Version X` region contains entries, run `sacho import-unreleased` before
+creating fragments. Inspect and confirm its normalization diff; in a
+noninteractive workflow, review the diff from the refused run before using
+`--force`. The command creates deterministic *imported-unreleased.md* fragments
+and infers the next version from `Version X`. If there are no current entries,
+skip the import and set the version with `sacho next 1.2.0`.
 
 Two configuration decisions matter early, both covered in
 `reference/configuration.md`: whether to enforce fragment coverage


### PR DESCRIPTION
Projects adopting Sacho may already have unreleased notes in *CHANGES.md*. Those notes cannot be recovered with `sacho carry`, which deliberately reads a frozen release, and `sacho sync --force` would discard them because no fragments exist yet. This left adoption dependent on a manual rewrite at the point where Sacho should be establishing fragments as the source of truth.

This PR treats that transition as a separate import rather than broadening `carry`. `sacho import-unreleased` reads only the current `Unreleased` or `Version X` region, converts its entries into deterministic *imported-unreleased.md* fragments, and compiles those fragments back through Sacho's normal materialization path. Released history is never an import input and remains byte-for-byte unchanged.


Preserve structure by asking, not guessing
------------------------------------------

An existing changelog often uses level-three headings, but their meaning is ambiguous. A heading such as `core` may be a stable repository section, while `Added` may only be a change category. Treating every heading as configuration would turn a formatting convention into a permanent *sacho.toml* decision.

Interactive `sacho init` therefore discovers candidates only inside version regions, orders candidates from the current unreleased region before released history, and shows occurrence counts. The user chooses which headings are real sections. Directory names and source path globs are inferred as editable defaults, so initialization can use the repository's layout without claiming that the inference is authoritative.

The importer then requires every level-three heading to match one of those configured sections. Sectioned changelogs produce one fragment per populated section; unsectioned changelogs produce one fragment at the fragment root.


Make losslessness a precondition
--------------------------------

The import parser accepts the narrow shape that Sacho fragments can reproduce: one version heading, the configured unreleased line, configured section headings, and top-level unordered lists. It rejects prose, ordered lists, unknown headings, repeated version headings, and existing Markdown fragments. Rejecting these inputs is preferable to flattening or silently dropping handwritten structure.

Reference definitions are folded back into imported entries before each fragment is formatted and parsed with the regular fragment parser. The result is compiled once more and compared with the original unreleased region. When normalization changes the materialized text, the command shows the diff and asks for confirmation. `--force` waives that confirmation for noninteractive use, but it does not bypass representability checks.

A `Version X` heading also supplies *changes.d/next*. An existing next-version value must match, which keeps the import from resolving conflicting release intent by accident. A plain `Unreleased` heading leaves the next-version file absent.


Commit the transition as one mutation
-------------------------------------

Planning is read-only. The plan records the changelog, next-version file, generated fragments, and the expected fragment set as participants in one repository mutation. Application takes the mutation lock, revalidates every participant, and rejects concurrent fragment additions before the first write. If a later write fails, earlier writes are rolled back without overwriting a concurrent edit.

This uses the same plan/apply boundary as Sacho's other mutating commands. The one-time adoption path therefore has the same stale-input and partial-write protections as ordinary changelog maintenance.
