### PR TITLE
Preserve redirected reference destinations

### DIFF
--- a/.hongdown.toml
+++ b/.hongdown.toml
@@ -5,4 +5,5 @@ exclude = [
   "**/node_modules/**",
   "**/.vitepress/**",
   ".git/**",
+  "changes.d/**",
 ]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,13 +8,14 @@ To be released.
 
  -  Added optional HTTP redirect resolution for fragment references, including
     persistent per-fragment URL pins and command-line overrides for previews,
-    synchronization, and releases.
+    synchronization, and releases.  [[#2]]
  -  Added `sacho import-unreleased` for converting an existing materialized
     unreleased region into fragments without rewriting released history.  [[#1]]
  -  Added interactive section suggestions to `sacho init` based on headings
     found across an existing changelog.  [[#1]]
 
-[#1]: https://github.com/dahlia/sacho/issues/1
+[#1]: https://github.com/dahlia/sacho/pull/1
+[#2]: https://github.com/dahlia/sacho/pull/2
 
 
 Version 0.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Version 0.2.0
 
 To be released.
 
+ -  Added optional HTTP redirect resolution for fragment references, including
+    persistent per-fragment URL pins and command-line overrides for previews,
+    synchronization, and releases.
  -  Added `sacho import-unreleased` for converting an existing materialized
     unreleased region into fragments without rewriting released history.  [[#1]]
  -  Added interactive section suggestions to `sacho init` based on headings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -204,6 +204,12 @@ dependencies = [
  "regex-automata",
  "serde_core",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "caseless"
@@ -456,7 +462,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -519,7 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -700,6 +706,22 @@ name = "html-escape"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icu_collections"
@@ -1434,6 +1456,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,7 +1491,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1509,8 +1580,9 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
+ "ureq",
  "url",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1601,7 +1673,7 @@ checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1693,6 +1765,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "supports-color"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,7 +1845,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1777,7 +1855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2012,6 +2090,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2134,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -2070,6 +2188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,7 +2218,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2108,12 +2235,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2232,6 +2432,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ before committing:
 
 ~~~~ sh
 sacho fmt
+sacho resolve-links  # optional: pin final redirected reference URLs
 sacho preview
 sacho check
 ~~~~

--- a/changes.d/import-unreleased.md
+++ b/changes.d/import-unreleased.md
@@ -1,3 +1,7 @@
+---
+links:
+  '#1': https://github.com/dahlia/sacho/pull/1
+---
  -  Added `sacho import-unreleased` for converting an existing materialized
     unreleased region into fragments without rewriting released history.  [[#1]]
  -  Added interactive section suggestions to `sacho init` based on headings

--- a/changes.d/resolve-reference-links.md
+++ b/changes.d/resolve-reference-links.md
@@ -1,3 +1,7 @@
+---
+links:
+  '#2': https://github.com/dahlia/sacho/pull/2
+---
  -  Added optional HTTP redirect resolution for fragment references, including
     persistent per-fragment URL pins and command-line overrides for previews,
-    synchronization, and releases.
+    synchronization, and releases.  [[#2]]

--- a/changes.d/resolve-reference-links.md
+++ b/changes.d/resolve-reference-links.md
@@ -1,0 +1,3 @@
+ -  Added optional HTTP redirect resolution for fragment references, including
+    persistent per-fragment URL pins and command-line overrides for previews,
+    synchronization, and releases.

--- a/crates/sacho/Cargo.toml
+++ b/crates/sacho/Cargo.toml
@@ -29,6 +29,7 @@ snafu = "0.9.1"
 thiserror = "2.0.18"
 toml = "1.1.2"
 url = "2.5.8"
+ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 
 [dev-dependencies]
 assert_cmd = "2.2.2"

--- a/crates/sacho/proptest-regressions/commands.txt
+++ b/crates/sacho/proptest-regressions/commands.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 3fe482f08d243a0927e1fea80098f3154dd997192f19546586c4e99f8db00905 # shrinks to template = "/issues/{n}"

--- a/crates/sacho/src/cli.rs
+++ b/crates/sacho/src/cli.rs
@@ -10,8 +10,8 @@ use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme, Report};
 use sacho::commands::{
     AddOptions, CarryOptions, CheckOptions, CheckReport, CompileOptions, FormatOptions,
     ImportUnreleasedOptions, ImportUnreleasedPlan, InitOptions, InitResult, MutationCleanupWarning,
-    NextOptions, ReleaseDate, ReleaseOptions, ResolveLinksOptions, ShowOptions, SyncOptions,
-    SyncPlan, add_fragment, apply_format, apply_import_unreleased, apply_merge_driver,
+    NextOptions, ReleaseDate, ReleaseOptions, ResolveLinksOptions, ResolveLinksResult, ShowOptions,
+    SyncOptions, SyncPlan, add_fragment, apply_format, apply_import_unreleased, apply_merge_driver,
     apply_release, apply_resolve_links, apply_sync, carry, check, commit_message_hook,
     compile_unreleased_with_link_resolution, infer_repository_url, infer_section_paths,
     init_repository, initialization_root, mercurial_update_hook, plan_format,
@@ -367,7 +367,7 @@ impl Cli {
                     return Ok(ExitCode::from(2));
                 }
                 let result = apply_resolve_links(&repo, plan)?;
-                print_mutation_cleanup_warnings("sacho resolve-links", &result.cleanup_warnings);
+                print_resolve_links_result(&repo, "sacho resolve-links", result);
                 Ok(ExitCode::SUCCESS)
             }
             Command::Preview {
@@ -421,7 +421,7 @@ impl Cli {
                         return Ok(ExitCode::from(2));
                     }
                     let result = apply_resolve_links(&repo, plan)?;
-                    print_mutation_cleanup_warnings("sacho sync", &result.cleanup_warnings);
+                    print_resolve_links_result(&repo, "sacho sync", result);
                 } else {
                     let plan = plan_sync(&repo, SyncOptions { force })?;
                     if !confirm_sync_plan(&plan, None, policy)? {
@@ -537,6 +537,16 @@ fn print_mutation_cleanup_warnings(command: &str, warnings: &[MutationCleanupWar
             warning.path.display(),
             warning.message,
         );
+    }
+}
+
+fn print_resolve_links_result(repo: &Repository, command: &str, result: ResolveLinksResult) {
+    print_mutation_cleanup_warnings(command, &result.cleanup_warnings);
+    for path in result.changed_fragments {
+        println!("{}", path.display());
+    }
+    if result.changelog_changed {
+        println!("{}", repo.config().changelog.path.display());
     }
 }
 

--- a/crates/sacho/src/cli.rs
+++ b/crates/sacho/src/cli.rs
@@ -10,13 +10,15 @@ use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme, Report};
 use sacho::commands::{
     AddOptions, CarryOptions, CheckOptions, CheckReport, CompileOptions, FormatOptions,
     ImportUnreleasedOptions, ImportUnreleasedPlan, InitOptions, InitResult, MutationCleanupWarning,
-    NextOptions, ReleaseDate, ReleaseOptions, ShowOptions, SyncOptions, SyncPlan, add_fragment,
-    apply_format, apply_import_unreleased, apply_merge_driver, apply_release, apply_sync, carry,
-    check, commit_message_hook, compile_unreleased, infer_repository_url, infer_section_paths,
+    NextOptions, ReleaseDate, ReleaseOptions, ResolveLinksOptions, ShowOptions, SyncOptions,
+    SyncPlan, add_fragment, apply_format, apply_import_unreleased, apply_merge_driver,
+    apply_release, apply_resolve_links, apply_sync, carry, check, commit_message_hook,
+    compile_unreleased_with_link_resolution, infer_repository_url, infer_section_paths,
     init_repository, initialization_root, mercurial_update_hook, plan_format,
-    plan_import_unreleased, plan_release, plan_sync, reference_transaction_hook, set_next_version,
-    show, suggest_section_directory,
+    plan_import_unreleased, plan_release, plan_release_with_link_resolution, plan_resolve_links,
+    plan_sync, reference_transaction_hook, set_next_version, show, suggest_section_directory,
 };
+use sacho::link_resolution::LinkResolutionPolicy;
 use sacho::merge::{MergeDriverOptions, MergeDriverResult};
 use sacho::released::discover_section_candidates;
 use sacho::{Error, Repository, SectionConfig};
@@ -121,11 +123,30 @@ enum Command {
     /// Format changelog fragments.
     Fmt,
 
+    /// Resolve and pin unpinned reference links.
+    ResolveLinks,
+
     /// Print the compiled unreleased region.
     Preview {
         /// Section id to preview by itself.
         #[arg(long, help = "Section id to preview by itself")]
         section: Option<String>,
+
+        /// Resolve unpinned reference links for this preview.
+        #[arg(
+            long,
+            conflicts_with = "no_resolve_links",
+            help = "Resolve unpinned reference links"
+        )]
+        resolve_links: bool,
+
+        /// Do not resolve unpinned reference links.
+        #[arg(
+            long,
+            conflicts_with = "resolve_links",
+            help = "Do not resolve unpinned reference links"
+        )]
+        no_resolve_links: bool,
     },
 
     /// Print a released changelog section.
@@ -153,6 +174,22 @@ enum Command {
         /// Apply the sync even when existing edits would be discarded.
         #[arg(long, help = "Apply even when existing edits would be discarded")]
         force: bool,
+
+        /// Resolve and pin unpinned reference links before synchronizing.
+        #[arg(
+            long,
+            conflicts_with = "no_resolve_links",
+            help = "Resolve unpinned reference links"
+        )]
+        resolve_links: bool,
+
+        /// Do not resolve unpinned reference links.
+        #[arg(
+            long,
+            conflicts_with = "resolve_links",
+            help = "Do not resolve unpinned reference links"
+        )]
+        no_resolve_links: bool,
     },
 
     /// Compile fragments into a released changelog section.
@@ -175,6 +212,22 @@ enum Command {
         /// Allow a release without substantive changelog items.
         #[arg(long, help = "Allow a release without changelog items")]
         allow_empty: bool,
+
+        /// Resolve unpinned reference links before releasing.
+        #[arg(
+            long,
+            conflicts_with = "no_resolve_links",
+            help = "Resolve unpinned reference links"
+        )]
+        resolve_links: bool,
+
+        /// Do not resolve unpinned reference links.
+        #[arg(
+            long,
+            conflicts_with = "resolve_links",
+            help = "Do not resolve unpinned reference links"
+        )]
+        no_resolve_links: bool,
     },
 
     /// Carry entries from a released section back into fragments.
@@ -269,7 +322,11 @@ impl Cli {
                 let repo = Repository::open_existing(".").map_err(CliReport::from)?;
                 if fix {
                     let prepared = plan_format(&repo, FormatOptions)?;
-                    if !confirm_sync_plan(&prepared.sync, Some("sacho check --fix"))? {
+                    if !confirm_sync_plan(
+                        &prepared.sync,
+                        Some("sacho check --fix"),
+                        LinkResolutionPolicy::Configured,
+                    )? {
                         return Ok(ExitCode::from(2));
                     }
                     let result = apply_format(&repo, prepared)?;
@@ -288,21 +345,44 @@ impl Cli {
             Command::Fmt => {
                 let repo = Repository::open_existing(".").map_err(CliReport::from)?;
                 let plan = plan_format(&repo, FormatOptions)?;
-                if !confirm_sync_plan(&plan.sync, Some("sacho fmt"))? {
+                if !confirm_sync_plan(
+                    &plan.sync,
+                    Some("sacho fmt"),
+                    LinkResolutionPolicy::Configured,
+                )? {
                     return Ok(ExitCode::from(2));
                 }
                 let result = apply_format(&repo, plan)?;
                 print_mutation_cleanup_warnings("sacho fmt", &result.cleanup_warnings);
                 Ok(ExitCode::SUCCESS)
             }
-            Command::Preview { section } => {
+            Command::ResolveLinks => {
                 let repo = Repository::open_existing(".").map_err(CliReport::from)?;
-                let compiled = compile_unreleased(
+                let plan = plan_resolve_links(&repo, ResolveLinksOptions::default())?;
+                if !confirm_sync_plan(
+                    &plan.sync,
+                    Some("sacho resolve-links"),
+                    LinkResolutionPolicy::Configured,
+                )? {
+                    return Ok(ExitCode::from(2));
+                }
+                let result = apply_resolve_links(&repo, plan)?;
+                print_mutation_cleanup_warnings("sacho resolve-links", &result.cleanup_warnings);
+                Ok(ExitCode::SUCCESS)
+            }
+            Command::Preview {
+                section,
+                resolve_links,
+                no_resolve_links,
+            } => {
+                let repo = Repository::open_existing(".").map_err(CliReport::from)?;
+                let compiled = compile_unreleased_with_link_resolution(
                     &repo,
                     CompileOptions {
                         section,
                         include_empty_region: true,
                     },
+                    link_resolution_policy(resolve_links, no_resolve_links),
                 )?;
                 print!("{}", compiled.markdown);
                 Ok(ExitCode::SUCCESS)
@@ -328,13 +408,27 @@ impl Cli {
                 }
                 Ok(ExitCode::SUCCESS)
             }
-            Command::Sync { force } => {
+            Command::Sync {
+                force,
+                resolve_links,
+                no_resolve_links,
+            } => {
                 let repo = Repository::open_existing(".").map_err(CliReport::from)?;
-                let plan = plan_sync(&repo, SyncOptions { force })?;
-                if !confirm_sync_plan(&plan, None)? {
-                    return Ok(ExitCode::from(2));
+                let policy = link_resolution_policy(resolve_links, no_resolve_links);
+                if policy.is_enabled(repo.config()) {
+                    let plan = plan_resolve_links(&repo, ResolveLinksOptions { force })?;
+                    if !confirm_sync_plan(&plan.sync, None, policy)? {
+                        return Ok(ExitCode::from(2));
+                    }
+                    let result = apply_resolve_links(&repo, plan)?;
+                    print_mutation_cleanup_warnings("sacho sync", &result.cleanup_warnings);
+                } else {
+                    let plan = plan_sync(&repo, SyncOptions { force })?;
+                    if !confirm_sync_plan(&plan, None, policy)? {
+                        return Ok(ExitCode::from(2));
+                    }
+                    apply_sync(&repo, plan)?;
                 }
-                apply_sync(&repo, plan)?;
                 Ok(ExitCode::SUCCESS)
             }
             Command::Release {
@@ -342,18 +436,23 @@ impl Cli {
                 date,
                 next,
                 allow_empty,
+                resolve_links,
+                no_resolve_links,
             } => {
                 let repo = Repository::open_existing(".").map_err(CliReport::from)?;
                 let date = resolve_release_date(date)?;
-                let plan = plan_release(
-                    &repo,
-                    ReleaseOptions {
-                        version,
-                        date,
-                        next,
-                        allow_empty,
-                    },
-                )?;
+                let options = ReleaseOptions {
+                    version,
+                    date,
+                    next,
+                    allow_empty,
+                };
+                let policy = link_resolution_policy(resolve_links, no_resolve_links);
+                let plan = if policy.is_enabled(repo.config()) {
+                    plan_release_with_link_resolution(&repo, options)?
+                } else {
+                    plan_release(&repo, options)?
+                };
                 apply_release(&repo, plan)?;
                 Ok(ExitCode::SUCCESS)
             }
@@ -490,7 +589,11 @@ fn print_check_report(report: CheckReport, show_skipped: bool) -> ExitCode {
     }
 }
 
-fn confirm_sync_plan(plan: &SyncPlan, formatting_command: Option<&str>) -> Result<bool, CliReport> {
+fn confirm_sync_plan(
+    plan: &SyncPlan,
+    formatting_command: Option<&str>,
+    link_policy: LinkResolutionPolicy,
+) -> Result<bool, CliReport> {
     let SyncPlan::NeedsConfirmation { diff, .. } = plan else {
         return Ok(true);
     };
@@ -506,12 +609,13 @@ fn confirm_sync_plan(plan: &SyncPlan, formatting_command: Option<&str>) -> Resul
         eprintln!(
             "the synchronization shown above replaces the materialized unreleased region and may discard hand edits"
         );
+        let sync_command = sync_force_command(link_policy);
         if let Some(command) = formatting_command {
             eprintln!(
-                "run `sacho sync --force`, then rerun `{command}` to apply all fixes non-interactively"
+                "run `{sync_command}`, then rerun `{command}` to apply all fixes non-interactively"
             );
         } else {
-            eprintln!("rerun with `sacho sync --force` to apply it non-interactively");
+            eprintln!("rerun with `{sync_command}` to apply it non-interactively");
         }
         return Ok(false);
     }
@@ -520,6 +624,24 @@ fn confirm_sync_plan(plan: &SyncPlan, formatting_command: Option<&str>) -> Resul
     } else {
         eprintln!("synchronization cancelled; the repository was not changed");
         Ok(false)
+    }
+}
+
+fn sync_force_command(policy: LinkResolutionPolicy) -> &'static str {
+    match policy {
+        LinkResolutionPolicy::Always => "sacho sync --resolve-links --force",
+        LinkResolutionPolicy::Never => "sacho sync --no-resolve-links --force",
+        LinkResolutionPolicy::Configured => "sacho sync --force",
+    }
+}
+
+fn link_resolution_policy(resolve_links: bool, no_resolve_links: bool) -> LinkResolutionPolicy {
+    if resolve_links {
+        LinkResolutionPolicy::Always
+    } else if no_resolve_links {
+        LinkResolutionPolicy::Never
+    } else {
+        LinkResolutionPolicy::Configured
     }
 }
 
@@ -998,6 +1120,32 @@ mod tests {
             panic!("expected init command");
         };
         assert_eq!(integration_executable, Some(PathBuf::from("tools/sacho-1")));
+    }
+
+    #[test]
+    fn link_resolution_flags_are_mutually_exclusive() {
+        for command in ["preview", "sync", "release"] {
+            let error =
+                Cli::try_parse_from(["sacho", command, "--resolve-links", "--no-resolve-links"])
+                    .expect_err("conflicting link resolution flags");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
+    }
+
+    #[test]
+    fn link_resolution_flags_select_the_expected_policy() {
+        assert_eq!(
+            link_resolution_policy(true, false),
+            LinkResolutionPolicy::Always
+        );
+        assert_eq!(
+            link_resolution_policy(false, true),
+            LinkResolutionPolicy::Never
+        );
+        assert_eq!(
+            link_resolution_policy(false, false),
+            LinkResolutionPolicy::Configured
+        );
     }
 
     #[test]

--- a/crates/sacho/src/commands.rs
+++ b/crates/sacho/src/commands.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ffi::OsStr;
 use std::fs;
 use std::io::{ErrorKind, Write};
@@ -17,7 +17,10 @@ use crate::changelog::{
     marker_region_contents, replace_unreleased_region, set_hongdown_separator_before,
     set_trailing_newline_count,
 };
-use crate::compile::{VersionLabel, compile_parsed_fragments, version_label_from_contents};
+use crate::compile::{
+    VersionLabel, compile_parsed_fragments, validate_resolved_link_consistency,
+    version_label_from_contents,
+};
 use crate::config::{
     Config, ReferenceSigil, RegionDetection, SectionConfig, UrlTemplate, VcsPreset,
 };
@@ -26,6 +29,7 @@ use crate::fragment::{
     DiscoveryWarning, Fragment, FragmentWarning, compare_fragment_paths,
     discover_fragment_candidates, parse_fragment,
 };
+use crate::link_resolution::{LinkResolutionPolicy, ReferenceUrlResolver, is_http_reference_url};
 use crate::markdown::format_markdown;
 use crate::merge::{MergeDriverOptions, MergeDriverResult, merge_driver};
 use crate::released::{
@@ -203,6 +207,15 @@ struct FormatFragmentSnapshot {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedFragmentSnapshot {
+    path: PathBuf,
+    before: String,
+    after: String,
+    parsed_before: Fragment,
+    parsed_after: Fragment,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct FormatFileSnapshot {
     path: PathBuf,
     contents: Option<String>,
@@ -285,6 +298,38 @@ pub enum SyncPlan {
 pub struct SyncResult {
     /// Whether applying the plan changed the changelog file.
     pub changed: bool,
+}
+
+/// Planned resolution of unpinned reference links.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolveLinksPlan {
+    /// Fragment paths whose frontmatter will change.
+    pub changed_fragments: Vec<PathBuf>,
+
+    /// Materialized changelog synchronization produced by the resolved links.
+    pub sync: SyncPlan,
+
+    mutation: RepositoryMutationPlan,
+}
+
+/// Options for resolving and pinning reference links.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResolveLinksOptions {
+    /// Apply materialized synchronization even when it may discard hand edits.
+    pub force: bool,
+}
+
+/// Result of resolving and pinning reference links.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ResolveLinksResult {
+    /// Fragment paths whose frontmatter changed.
+    pub changed_fragments: Vec<PathBuf>,
+
+    /// Whether the materialized changelog changed.
+    pub changelog_changed: bool,
+
+    /// Non-fatal failures while removing committed transaction claims.
+    pub cleanup_warnings: Vec<MutationCleanupWarning>,
 }
 
 /// Options for planning a release.
@@ -1345,6 +1390,307 @@ pub fn compile_unreleased(repo: &Repository, options: CompileOptions) -> Result<
     crate::compile::compile_unreleased(repo, options)
 }
 
+/// Compiles the current fragments, optionally resolving unpinned links in memory.
+///
+/// This function never writes fragment or changelog files.
+pub fn compile_unreleased_with_link_resolution(
+    repo: &Repository,
+    options: CompileOptions,
+    policy: LinkResolutionPolicy,
+) -> Result<CompiledRegion> {
+    if !policy.is_enabled(repo.config()) {
+        return compile_unreleased(repo, options);
+    }
+    let snapshots = prepare_resolved_fragments(repo, options.section.as_deref())?;
+    let version_label = current_version_label(repo)?;
+    compile_parsed_fragments(
+        repo,
+        options,
+        version_label,
+        snapshots
+            .into_iter()
+            .map(|snapshot| snapshot.parsed_after)
+            .collect(),
+    )
+}
+
+/// Plans link resolution and any materialized changelog synchronization.
+///
+/// Planning completes every network request but does not write repository files.
+pub fn plan_resolve_links(
+    repo: &Repository,
+    options: ResolveLinksOptions,
+) -> Result<ResolveLinksPlan> {
+    plan_resolve_links_with_snapshot_hook(repo, options, || {})
+}
+
+fn plan_resolve_links_with_snapshot_hook(
+    repo: &Repository,
+    options: ResolveLinksOptions,
+    after_next_snapshot: impl FnOnce(),
+) -> Result<ResolveLinksPlan> {
+    let snapshots = prepare_resolved_fragments(repo, None)?;
+    let changed_fragments = snapshots
+        .iter()
+        .filter(|snapshot| snapshot.before != snapshot.after)
+        .map(|snapshot| snapshot.path.clone())
+        .collect::<Vec<_>>();
+    let fragment_paths = snapshots
+        .iter()
+        .map(|snapshot| snapshot.path.clone())
+        .collect::<Vec<_>>();
+    let mut participants = snapshots
+        .iter()
+        .map(|snapshot| ReleaseFileChange {
+            path: snapshot.path.clone(),
+            before: ReleaseFileState::Present(snapshot.before.clone()),
+            after: ReleaseFileState::Present(snapshot.after.clone()),
+        })
+        .collect::<Vec<_>>();
+
+    let sync = if repo.config().changelog.materialize {
+        let next_path = next_version_path(repo);
+        let next_file = read_format_file_snapshot(repo, &next_path)?;
+        let version_label =
+            version_label_from_contents(&repo.resolve(&next_path), next_file.contents.as_deref())?;
+        after_next_snapshot();
+        let compiled_before = compile_parsed_fragments(
+            repo,
+            CompileOptions::default(),
+            version_label.clone(),
+            snapshots
+                .iter()
+                .map(|snapshot| snapshot.parsed_before.clone())
+                .collect(),
+        )?;
+        let compiled_after = compile_parsed_fragments(
+            repo,
+            CompileOptions::default(),
+            version_label,
+            snapshots
+                .iter()
+                .map(|snapshot| snapshot.parsed_after.clone())
+                .collect(),
+        )?;
+        let next_state = release_state_from_optional_contents(next_file.contents);
+        participants.push(ReleaseFileChange {
+            path: next_path,
+            before: next_state.clone(),
+            after: next_state,
+        });
+
+        let changelog_path = repo.config().changelog.path.clone();
+        let changelog = read_format_file_snapshot(repo, &changelog_path)?;
+        let old_contents = changelog.contents.ok_or_else(|| Error::ReadFile {
+            path: repo.resolve(&changelog_path),
+            source: std::io::Error::new(ErrorKind::NotFound, "changelog does not exist"),
+        })?;
+        let (expected_before, _) = synchronize_materialized_changelog(
+            repo,
+            &old_contents,
+            &compiled_before,
+            &changelog_path,
+        )?;
+        let generated_change_only = expected_before == old_contents;
+        let sync = plan_sync_from_contents(
+            repo,
+            &compiled_after,
+            old_contents.clone(),
+            SyncOptions {
+                force: options.force || generated_change_only,
+            },
+        )?;
+        let after = format_sync_pending(&sync).map_or_else(
+            || ReleaseFileState::Present(old_contents.clone()),
+            |pending| ReleaseFileState::Present(pending.new_contents.clone()),
+        );
+        participants.push(ReleaseFileChange {
+            path: changelog_path,
+            before: ReleaseFileState::Present(old_contents),
+            after,
+        });
+        sync
+    } else {
+        SyncPlan::Skipped(SyncSkipReason::MaterializationDisabled)
+    };
+
+    Ok(ResolveLinksPlan {
+        changed_fragments,
+        sync,
+        mutation: RepositoryMutationPlan {
+            command: MutationCommand::ResolveLinks,
+            participants,
+            fragment_paths_before: fragment_paths.clone(),
+            fragment_paths_after: fragment_paths,
+        },
+    })
+}
+
+/// Applies a previously planned reference-link resolution.
+pub fn apply_resolve_links(
+    repo: &Repository,
+    plan: ResolveLinksPlan,
+) -> Result<ResolveLinksResult> {
+    let _lock = acquire_mutation_lock(repo)?;
+    let changelog_changed = format_sync_pending(&plan.sync)
+        .is_some_and(|pending| pending.old_contents != pending.new_contents);
+    let changed_fragments = plan.changed_fragments;
+    let outcome = apply_repository_mutation(repo, &plan.mutation)?;
+    Ok(ResolveLinksResult {
+        changed_fragments,
+        changelog_changed,
+        cleanup_warnings: outcome.cleanup_warnings,
+    })
+}
+
+fn current_version_label(repo: &Repository) -> Result<VersionLabel> {
+    let path = next_version_path(repo);
+    let snapshot = read_format_file_snapshot(repo, &path)?;
+    version_label_from_contents(&repo.resolve(&path), snapshot.contents.as_deref())
+}
+
+fn prepare_resolved_fragments(
+    repo: &Repository,
+    resolve_section: Option<&str>,
+) -> Result<Vec<ResolvedFragmentSnapshot>> {
+    let discovered = discover_fragment_candidates(repo)?;
+    let mut parsed = Vec::with_capacity(discovered.candidates.len());
+    let mut targets = BTreeMap::<String, (String, u64)>::new();
+    let mut resolved = BTreeMap::<String, String>::new();
+
+    for candidate in discovered.candidates {
+        let should_resolve =
+            resolve_section.is_none_or(|section| candidate.section.as_deref() == Some(section));
+        let source = fs::read_to_string(&candidate.path).map_err(|source| Error::ReadFile {
+            path: candidate.path.clone(),
+            source,
+        })?;
+        let fragment = parse_fragment(
+            candidate.relative_path.clone(),
+            &source,
+            candidate.section.clone(),
+            &repo.config().links,
+        )
+        .map_err(|source| Error::Fragment {
+            path: candidate.relative_path.clone(),
+            source,
+        })?;
+        let used = fragment
+            .items
+            .iter()
+            .flat_map(|item| item.references.iter())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        for reference in &used {
+            if should_resolve {
+                targets
+                    .entry(reference.label.clone())
+                    .or_insert_with(|| (reference.sigil.clone(), reference.number));
+            }
+            if let Some(url) = fragment.links.get(&reference.label) {
+                if let Some(existing) = resolved.get(&reference.label)
+                    && existing != url
+                {
+                    return Err(Error::ConflictingResolvedLinks {
+                        label: reference.label.clone(),
+                        first: existing.clone(),
+                        second: url.clone(),
+                    });
+                }
+                resolved.insert(reference.label.clone(), url.clone());
+            }
+        }
+        parsed.push((
+            candidate.relative_path,
+            candidate.section,
+            source,
+            fragment,
+            used,
+            should_resolve,
+        ));
+    }
+
+    let resolver = ReferenceUrlResolver::new();
+    for (label, (sigil, number)) in &targets {
+        if resolved.contains_key(label) {
+            continue;
+        }
+        let template = repo
+            .config()
+            .links
+            .iter()
+            .find(|(configured, _)| configured.as_str() == sigil)
+            .map(|(_, template)| template)
+            .expect("parsed references always retain a configured sigil");
+        let source_url = template.as_str().replace("{n}", &number.to_string());
+        if !is_http_reference_url(&source_url) {
+            continue;
+        }
+        resolved.insert(label.clone(), resolver.resolve(label, &source_url)?);
+    }
+
+    parsed
+        .into_iter()
+        .map(
+            |(path, section, before, parsed_before, used, should_resolve)| {
+                if !should_resolve {
+                    return Ok(ResolvedFragmentSnapshot {
+                        path,
+                        after: before.clone(),
+                        before,
+                        parsed_after: parsed_before.clone(),
+                        parsed_before,
+                    });
+                }
+                let links = used
+                    .iter()
+                    .filter_map(|reference| {
+                        resolved
+                            .get(&reference.label)
+                            .map(|url| (reference.label.clone(), url.clone()))
+                    })
+                    .collect::<BTreeMap<_, _>>();
+                let after = source_with_resolved_links(&before, &links)
+                    .map_err(|error| with_fragment_path(error, path.clone()))?;
+                let parsed_after =
+                    parse_fragment(path.clone(), &after, section, &repo.config().links).map_err(
+                        |source| Error::Fragment {
+                            path: path.clone(),
+                            source,
+                        },
+                    )?;
+                Ok(ResolvedFragmentSnapshot {
+                    path,
+                    before,
+                    after,
+                    parsed_before,
+                    parsed_after,
+                })
+            },
+        )
+        .collect()
+}
+
+fn source_with_resolved_links(source: &str, links: &BTreeMap<String, String>) -> Result<String> {
+    let mut parsed = parse_frontmatter_for_format(source)?;
+    parsed
+        .frontmatter
+        .retain(|entry| entry.key != Value::String(String::from("links")));
+    if !links.is_empty() {
+        let mut mapping = Mapping::new();
+        for (label, url) in links {
+            mapping.insert(Value::String(label.clone()), Value::String(url.clone()));
+        }
+        parsed.frontmatter.push(FrontmatterEntry {
+            key: Value::String(String::from("links")),
+            value: Value::Mapping(mapping),
+        });
+    }
+    let mut output = canonical_frontmatter(parsed.frontmatter)?;
+    output.push_str(parsed.body);
+    Ok(output)
+}
+
 /// Reads one released section from the configured changelog.
 pub fn show(repo: &Repository, options: ShowOptions) -> Result<ReleasedSection> {
     let config = &repo.config().changelog;
@@ -1504,6 +1850,26 @@ fn apply_sync_unlocked(repo: &Repository, plan: SyncPlan) -> Result<SyncResult> 
 
 /// Plans a release operation.
 pub fn plan_release(repo: &Repository, options: ReleaseOptions) -> Result<ReleasePlan> {
+    plan_release_with_resolved_fragments(repo, options, None)
+}
+
+/// Plans a release whose unpinned reference links are resolved in memory.
+///
+/// The consumed fragment files are not rewritten before they are removed by
+/// [`apply_release`].
+pub fn plan_release_with_link_resolution(
+    repo: &Repository,
+    options: ReleaseOptions,
+) -> Result<ReleasePlan> {
+    let resolved = prepare_resolved_fragments(repo, None)?;
+    plan_release_with_resolved_fragments(repo, options, Some(resolved))
+}
+
+fn plan_release_with_resolved_fragments(
+    repo: &Repository,
+    options: ReleaseOptions,
+    resolved: Option<Vec<ResolvedFragmentSnapshot>>,
+) -> Result<ReleasePlan> {
     let _lock = acquire_mutation_lock(repo)?;
 
     let changelog_path = repo.config().changelog.path.clone();
@@ -1540,23 +1906,57 @@ pub fn plan_release(repo: &Repository, options: ReleaseOptions) -> Result<Releas
             date: format!("{:04}-{:02}-{:02}", date.year, date.month, date.day),
         });
     }
-    let (consumed_fragments, parsed_fragments) = snapshot_release_fragments(repo)?;
+    let (consumed_fragments, parsed_fragments_before) = snapshot_release_fragments(repo)?;
+    let parsed_fragments = if let Some(resolved) = resolved {
+        if consumed_fragments.len() != resolved.len() {
+            return Err(Error::StaleReleasePlan {
+                path: resolved
+                    .first()
+                    .map(|planned| planned.path.clone())
+                    .unwrap_or_else(|| repo.config().fragments.directory.clone()),
+            });
+        }
+        for (actual, planned) in consumed_fragments.iter().zip(&resolved) {
+            if actual.path != planned.path {
+                return Err(Error::StaleReleasePlan {
+                    path: planned.path.clone(),
+                });
+            }
+            if actual.contents != planned.before {
+                return Err(Error::StaleReleasePlan {
+                    path: planned.path.clone(),
+                });
+            }
+        }
+        resolved
+            .into_iter()
+            .map(|snapshot| snapshot.parsed_after)
+            .collect()
+    } else {
+        parsed_fragments_before.clone()
+    };
     let version_label = next_version
         .as_ref()
         .map_or(VersionLabel::Unreleased, |version| {
             VersionLabel::Version(version.clone())
         });
-    let compiled = compile_parsed_fragments(
+    let compiled_before = compile_parsed_fragments(
         repo,
         CompileOptions::default(),
-        version_label,
-        parsed_fragments,
+        version_label.clone(),
+        parsed_fragments_before,
     )?;
     ensure_materialized_release_snapshot_current(
         repo,
         &changelog_path,
         &changelog_before,
-        &compiled,
+        &compiled_before,
+    )?;
+    let compiled = compile_parsed_fragments(
+        repo,
+        CompileOptions::default(),
+        version_label,
+        parsed_fragments,
     )?;
     let old_changelog = release_file_state_utf8(repo, &changelog_path, &changelog_before)?
         .map_or_else(
@@ -1983,6 +2383,9 @@ fn plan_carry_mutation(
         .materialize
         .then(|| parse_release_fragment_sources(repo, &after_sources))
         .transpose()?;
+    if parsed_after.is_none() {
+        validate_parseable_fragment_pin_consistency(repo, &after_sources)?;
+    }
     let next_path = next_version_path(repo);
     let next_state = read_release_file_state(repo, &next_path)?;
     let mut participants = Vec::with_capacity(after_sources.len() + 2);
@@ -2171,6 +2574,10 @@ pub fn check(repo: &Repository, options: CheckOptions) -> Result<CheckReport> {
     }
 
     if violations.is_empty() {
+        // Validate repository-wide resolved-link consistency even when
+        // materialization is disabled. Compilation never performs network
+        // resolution on the check path.
+        compile_unreleased(repo, CompileOptions::default())?;
         match plan_sync(repo, SyncOptions { force: false })? {
             SyncPlan::NeedsConfirmation { diff, .. } => {
                 violations.push(CheckViolation {
@@ -3029,6 +3436,26 @@ fn parse_release_fragment_sources(
             })
         })
         .collect()
+}
+
+fn validate_parseable_fragment_pin_consistency(
+    repo: &Repository,
+    sources: &[ReleaseFragmentSource],
+) -> Result<()> {
+    let fragments = sources
+        .iter()
+        .filter_map(|source| {
+            let contents = std::str::from_utf8(&source.contents).ok()?;
+            parse_fragment(
+                source.path.clone(),
+                contents,
+                source.section.clone(),
+                &repo.config().links,
+            )
+            .ok()
+        })
+        .collect::<Vec<_>>();
+    validate_resolved_link_consistency(&fragments)
 }
 
 struct MutationLock {
@@ -4947,6 +5374,16 @@ fn canonical_frontmatter(mut frontmatter: Vec<FrontmatterEntry>) -> Result<Strin
         return Ok(String::new());
     }
 
+    for entry in &mut frontmatter {
+        if entry.key == Value::String(String::from("links"))
+            && let Value::Mapping(mapping) = &entry.value
+        {
+            let mut values = mapping.clone().into_iter().collect::<Vec<_>>();
+            values.sort_by_key(|(key, _)| yaml_key_sort_text(key));
+            entry.value = Value::Mapping(values.into_iter().collect());
+        }
+    }
+
     let mut output = String::from("---\n");
     if priority != 0 {
         output.push_str("priority: ");
@@ -5986,7 +6423,10 @@ fn unified_diff(old_contents: &str, new_contents: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::io::{BufRead, BufReader, Write as _};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
     use std::path::{Path, PathBuf};
+    use std::thread;
 
     use proptest::prelude::*;
     use tempfile::TempDir;
@@ -6083,6 +6523,80 @@ mod tests {
         fs::write(temp.path().join("sacho.toml"), config).expect("config");
         let repo = Repository::from_root(temp.path()).expect("repo");
         (temp, repo)
+    }
+
+    struct TestHttpServer {
+        base: String,
+        address: SocketAddr,
+        response_count: usize,
+        handle: Option<thread::JoinHandle<Vec<String>>>,
+    }
+
+    impl TestHttpServer {
+        fn spawn(responses: Vec<String>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+            let address = listener.local_addr().expect("address");
+            let base = format!("http://{address}");
+            let response_count = responses.len();
+            let handle = thread::spawn(move || {
+                let mut requests = Vec::new();
+                for response in responses {
+                    let (mut stream, _) = listener.accept().expect("connection");
+                    requests.push(
+                        BufReader::new(&stream)
+                            .lines()
+                            .next()
+                            .expect("request line")
+                            .expect("request contents"),
+                    );
+                    stream.write_all(response.as_bytes()).expect("response");
+                }
+                requests
+            });
+            Self {
+                base,
+                address,
+                response_count,
+                handle: Some(handle),
+            }
+        }
+
+        fn finish(mut self) -> Vec<String> {
+            wake_http_server(self.address, self.response_count);
+            self.handle.take().expect("handle").join().expect("server")
+        }
+    }
+
+    impl Drop for TestHttpServer {
+        fn drop(&mut self) {
+            let Some(handle) = self.handle.take() else {
+                return;
+            };
+            wake_http_server(self.address, self.response_count);
+            handle.join().expect("server");
+        }
+    }
+
+    fn wake_http_server(address: SocketAddr, attempts: usize) {
+        for _ in 0..attempts {
+            let Ok(mut stream) = TcpStream::connect(address) else {
+                break;
+            };
+            stream
+                .write_all(b"HEAD /test-server-shutdown HTTP/1.1\r\n\r\n")
+                .expect("shutdown request");
+        }
+    }
+
+    fn http_response(status: &str, location: Option<&str>) -> String {
+        let mut output = format!("HTTP/1.1 {status}\r\nConnection: close\r\nContent-Length: 0\r\n");
+        if let Some(location) = location {
+            output.push_str("Location: ");
+            output.push_str(location);
+            output.push_str("\r\n");
+        }
+        output.push_str("\r\n");
+        output
     }
 
     fn release_date() -> ReleaseDate {
@@ -7978,7 +8492,7 @@ mod tests {
         .expect("old fragment");
         fs::write(
             temp.path().join("CHANGES.md"),
-            "Version 1.1.5\n-------------\n\nReleased on July 1, 2026.\n\n -  Fixed carry.  [[#8]]\n\n[#8]: https://example.com/issues/8\n",
+            "Version 1.1.5\n-------------\n\nReleased on July 1, 2026.\n\n -  Fixed carry.  [[#8](https://example.com/pull/8)]\n\n[#8]: https://example.com/pull/8\n",
         )
         .expect("changelog");
 
@@ -7998,8 +8512,37 @@ mod tests {
         assert_eq!(
             fs::read_to_string(temp.path().join("changes.d/carried-from-1.1.5.md"))
                 .expect("fragment"),
-            " -  Fixed carry.  [[#8]]\n"
+            "---\nlinks:\n  '#8': https://example.com/pull/8\n---\n -  Fixed carry.  [[#8]]\n"
         );
+    }
+
+    #[test]
+    fn import_unreleased_preserves_resolved_reference_destinations() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragment directory");
+        fs::write(
+            temp.path().join("CHANGES.md"),
+            "Version 2.4.0\n-------------\n\nTo be released.\n\n -  Fixed import.  [[#9](https://example.com/discussions/9)]\n\n[#9]: https://example.com/discussions/9\n",
+        )
+        .expect("changelog");
+
+        let plan = plan_import_unreleased(&repo, ImportUnreleasedOptions { force: true })
+            .expect("import plan");
+        apply_import_unreleased(&repo, plan).expect("apply import");
+
+        assert_eq!(
+            fs::read_to_string(temp.path().join("changes.d/imported-unreleased.md"))
+                .expect("fragment"),
+            "---\nlinks:\n  '#9': https://example.com/discussions/9\n---\n -  Fixed import.  [[#9]]\n"
+        );
+        let changelog = fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog");
+        assert!(changelog.contains("[#9]: https://example.com/discussions/9"));
+        assert!(!changelog.contains("[#9]: https://example.com/issues/9"));
     }
 
     #[test]
@@ -8108,6 +8651,55 @@ mod tests {
                 .expect("carried fragment"),
             " -  Fixed carry.\n"
         );
+    }
+
+    #[test]
+    fn fragments_only_carry_rejects_a_pin_conflicting_with_an_existing_fragment() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let existing = temp.path().join("changes.d/existing.md");
+        let existing_source = "\
+---
+links:
+  '#1': https://example.com/issues/1
+---
+ -  Existing change.  [[#1]]
+";
+        fs::write(&existing, existing_source).expect("existing fragment");
+        fs::write(
+            temp.path().join("CHANGES.md"),
+            "Version 1.1.5\n-------------\n\nReleased on July 1, 2026.\n\n -  Carried change.  [[#1](https://example.com/pull/1)]\n\n[#1]: https://example.com/pull/1\n",
+        )
+        .expect("changelog");
+
+        let error = carry(
+            &repo,
+            CarryOptions {
+                version: String::from("1.1.5"),
+            },
+        )
+        .expect_err("conflicting pins");
+
+        assert!(matches!(
+            error,
+            Error::ConflictingResolvedLinks { ref label, ref first, ref second }
+                if label == "#1"
+                    && first == "https://example.com/pull/1"
+                    && second == "https://example.com/issues/1"
+        ));
+        assert_eq!(
+            fs::read_to_string(existing).expect("existing fragment"),
+            existing_source
+        );
+        assert!(!temp.path().join("changes.d/carried-from-1.1.5.md").exists());
     }
 
     // APFS rejects the deliberately non-UTF-8 path before carry can inspect it.
@@ -8846,6 +9438,100 @@ mod tests {
             fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog"),
             "Project changes\n===============\n\nVersion 1.2.0\n-------------\n\nReleased on July 8, 2026.\n\n -\n\n\nVersion 1.1.0\n-------------\n\nReleased on July 1, 2026.\n"
         );
+    }
+
+    #[test]
+    fn release_resolves_links_in_memory_before_consuming_fragments() {
+        let server = TestHttpServer::spawn(vec![
+            http_response("302 Found", Some("/pull/3")),
+            http_response("200 OK", None),
+        ]);
+        let (temp, repo) = repo_with_config(&format!(
+            "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{}/issues/{{n}}\"\n",
+            server.base
+        ));
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        fs::write(temp.path().join("changes.d/next"), "0.2.0\n").expect("next");
+        fs::write(
+            temp.path().join("changes.d/release.md"),
+            " -  Fixed release links.  [[#3]]\n",
+        )
+        .expect("fragment");
+        fs::write(temp.path().join("CHANGES.md"), "Changelog\n=========\n").expect("changelog");
+
+        let plan = plan_release_with_link_resolution(
+            &repo,
+            ReleaseOptions {
+                version: None,
+                date: release_date(),
+                next: None,
+                allow_empty: false,
+            },
+        )
+        .expect("release plan");
+        assert!(
+            plan.released_markdown
+                .contains(&format!("[#3]: {}/pull/3", server.base))
+        );
+
+        apply_release(&repo, plan).expect("release");
+
+        assert!(!temp.path().join("changes.d/release.md").exists());
+        assert!(
+            fs::read_to_string(temp.path().join("CHANGES.md"))
+                .expect("changelog")
+                .contains(&format!("[#3]: {}/pull/3", server.base))
+        );
+        assert_eq!(
+            server.finish(),
+            vec!["HEAD /issues/3 HTTP/1.1", "HEAD /pull/3 HTTP/1.1"]
+        );
+    }
+
+    #[test]
+    fn resolving_release_rejects_a_fragment_changed_after_resolution() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "http://127.0.0.1:1/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        fs::write(temp.path().join("changes.d/next"), "0.2.0\n").expect("next");
+        let fragment = temp.path().join("changes.d/release.md");
+        fs::write(
+            &fragment,
+            "---\nlinks:\n  '#3': https://example.com/pull/3\n---\n -  Before.  [[#3]]\n",
+        )
+        .expect("fragment");
+        fs::write(temp.path().join("CHANGES.md"), "Changelog\n=========\n").expect("changelog");
+        let resolved = prepare_resolved_fragments(&repo, None).expect("resolved snapshots");
+        fs::write(
+            &fragment,
+            "---\nlinks:\n  '#3': https://example.com/pull/3\n---\n -  After.  [[#3]]\n",
+        )
+        .expect("concurrent edit");
+
+        let error = plan_release_with_resolved_fragments(
+            &repo,
+            ReleaseOptions {
+                version: None,
+                date: release_date(),
+                next: None,
+                allow_empty: false,
+            },
+            Some(resolved),
+        )
+        .expect_err("stale fragment");
+
+        assert!(matches!(
+            error,
+            Error::StaleReleasePlan { ref path }
+                if path == Path::new("changes.d/release.md")
+        ));
     }
 
     #[test]
@@ -11851,6 +12537,463 @@ mod tests {
     }
 
     #[test]
+    fn resolve_links_pins_fragments_and_syncs_generated_output_atomically() {
+        let server = TestHttpServer::spawn(vec![
+            http_response("302 Found", Some("/pull/1")),
+            http_response("200 OK", None),
+        ]);
+        let (temp, repo) = repo_with_config(&format!(
+            "[links]\n\"#\" = \"{}/issues/{{n}}\"\n",
+            server.base
+        ));
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let fragment_path = temp.path().join("changes.d/change.md");
+        let fragment_before = " -  Fixed links.  [[#1]]\n";
+        fs::write(&fragment_path, fragment_before).expect("fragment");
+        let compiled = compile_unreleased(&repo, CompileOptions::default()).expect("compile");
+        let changelog_before = format!("Changelog\n=========\n\n{}", compiled.markdown);
+        fs::write(temp.path().join("CHANGES.md"), &changelog_before).expect("changelog");
+
+        let plan = plan_resolve_links(&repo, ResolveLinksOptions::default()).expect("plan");
+
+        assert_eq!(
+            plan.changed_fragments,
+            vec![PathBuf::from("changes.d/change.md")]
+        );
+        assert!(matches!(plan.sync, SyncPlan::Apply(_)));
+        assert_eq!(
+            fs::read_to_string(&fragment_path).expect("fragment"),
+            fragment_before
+        );
+        assert_eq!(
+            fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog"),
+            changelog_before
+        );
+
+        let result = apply_resolve_links(&repo, plan).expect("apply");
+
+        assert!(result.changelog_changed);
+        let fragment = fs::read_to_string(&fragment_path).expect("resolved fragment");
+        assert!(fragment.contains("'#1':"));
+        assert!(fragment.contains(&format!("{}/pull/1", server.base)));
+        let changelog = fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog");
+        assert!(changelog.contains(&format!("[#1]: {}/pull/1", server.base)));
+        assert_eq!(
+            server.finish(),
+            vec!["HEAD /issues/1 HTTP/1.1", "HEAD /pull/1 HTTP/1.1"]
+        );
+    }
+
+    #[test]
+    fn resolving_preview_uses_existing_pin_without_writing_or_network() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "http://127.0.0.1:1/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let source =
+            "---\nlinks:\n  \"#1\": https://example.com/pull/1\n---\n -  Fixed links.  [[#1]]\n";
+        let path = temp.path().join("changes.d/change.md");
+        fs::write(&path, source).expect("fragment");
+
+        let compiled = compile_unreleased_with_link_resolution(
+            &repo,
+            CompileOptions::default(),
+            LinkResolutionPolicy::Always,
+        )
+        .expect("preview");
+
+        assert!(
+            compiled
+                .markdown
+                .contains("[#1]: https://example.com/pull/1")
+        );
+        assert_eq!(fs::read_to_string(path).expect("fragment"), source);
+    }
+
+    #[test]
+    fn resolving_preview_only_requests_links_from_the_selected_section() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "http://127.0.0.1:1/issues/{n}"
+
+            [[sections]]
+            id = "core"
+            directory = "core"
+
+            [[sections]]
+            id = "cli"
+            directory = "cli"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d/core")).expect("core fragments");
+        fs::create_dir_all(temp.path().join("changes.d/cli")).expect("CLI fragments");
+        fs::write(
+            temp.path().join("changes.d/core/change.md"),
+            "---\nlinks:\n  \"#1\": https://example.com/pull/1\n---\n -  Fixed core.  [[#1]]\n",
+        )
+        .expect("core fragment");
+        fs::write(
+            temp.path().join("changes.d/cli/change.md"),
+            " -  Fixed CLI.  [[#2]]\n",
+        )
+        .expect("CLI fragment");
+
+        let compiled = compile_unreleased_with_link_resolution(
+            &repo,
+            CompileOptions {
+                section: Some(String::from("core")),
+                ..CompileOptions::default()
+            },
+            LinkResolutionPolicy::Always,
+        )
+        .expect("selected preview");
+
+        assert!(compiled.markdown.contains("Fixed core."));
+        assert!(!compiled.markdown.contains("Fixed CLI."));
+        assert!(
+            compiled
+                .markdown
+                .contains("[#1]: https://example.com/pull/1")
+        );
+    }
+
+    #[test]
+    fn resolving_preview_uses_a_pin_from_an_unselected_section() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "http://127.0.0.1:1/issues/{n}"
+
+            [[sections]]
+            id = "core"
+            directory = "core"
+
+            [[sections]]
+            id = "cli"
+            directory = "cli"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d/core")).expect("core fragments");
+        fs::create_dir_all(temp.path().join("changes.d/cli")).expect("CLI fragments");
+        fs::write(
+            temp.path().join("changes.d/core/change.md"),
+            " -  Fixed core.  [[#1]]\n",
+        )
+        .expect("core fragment");
+        fs::write(
+            temp.path().join("changes.d/cli/change.md"),
+            "---\nlinks:\n  \"#1\": https://example.com/pull/1\n---\n -  Fixed CLI.  [[#1]]\n",
+        )
+        .expect("CLI fragment");
+
+        let compiled = compile_unreleased_with_link_resolution(
+            &repo,
+            CompileOptions {
+                section: Some(String::from("core")),
+                ..CompileOptions::default()
+            },
+            LinkResolutionPolicy::Always,
+        )
+        .expect("selected preview");
+
+        assert!(compiled.markdown.contains("Fixed core."));
+        assert!(!compiled.markdown.contains("Fixed CLI."));
+        assert!(
+            compiled
+                .markdown
+                .contains("[#1]: https://example.com/pull/1")
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn resolving_preview_leaves_non_http_references_unpinned(
+            template in prop_oneof![
+                Just("/issues/{n}"),
+                Just("mailto:issue-{n}@example.com"),
+            ],
+        ) {
+            let config = format!(
+                "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{template}\"\n"
+            );
+            let (temp, repo) = repo_with_config(&config);
+            fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+            fs::write(
+                temp.path().join("changes.d/change.md"),
+                " -  Fixed links.  [[#1]]\n",
+            )
+            .expect("fragment");
+
+            let compiled = compile_unreleased_with_link_resolution(
+                &repo,
+                CompileOptions::default(),
+                LinkResolutionPolicy::Always,
+            )
+            .expect("preview");
+
+            let expected = format!("[#1]: {}", template.replace("{n}", "1"));
+            prop_assert!(compiled.markdown.contains(&expected));
+        }
+    }
+
+    #[test]
+    fn resolve_links_still_pins_fragments_when_materialization_is_disabled() {
+        let server = TestHttpServer::spawn(vec![http_response("200 OK", None)]);
+        let (temp, repo) = repo_with_config(&format!(
+            "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{}/issues/{{n}}\"\n",
+            server.base
+        ));
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let path = temp.path().join("changes.d/change.md");
+        fs::write(&path, " -  Fixed links.  [[#1]]\n").expect("fragment");
+
+        let plan = plan_resolve_links(&repo, ResolveLinksOptions::default()).expect("plan");
+        assert!(matches!(
+            plan.sync,
+            SyncPlan::Skipped(SyncSkipReason::MaterializationDisabled)
+        ));
+        apply_resolve_links(&repo, plan).expect("apply");
+
+        assert!(
+            fs::read_to_string(path)
+                .expect("fragment")
+                .contains("links:")
+        );
+        assert_eq!(server.finish(), vec!["HEAD /issues/1 HTTP/1.1"]);
+    }
+
+    #[test]
+    fn resolve_links_requests_each_label_once_and_pins_every_using_fragment() {
+        let server = TestHttpServer::spawn(vec![http_response("200 OK", None)]);
+        let (temp, repo) = repo_with_config(&format!(
+            "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{}/issues/{{n}}\"\n",
+            server.base
+        ));
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let first = temp.path().join("changes.d/first.md");
+        let second = temp.path().join("changes.d/second.md");
+        fs::write(&first, " -  Fixed the first path.  [[#1]]\n").expect("first fragment");
+        fs::write(&second, " -  Fixed the second path.  [[#1]]\n").expect("second fragment");
+
+        let plan = plan_resolve_links(&repo, ResolveLinksOptions::default()).expect("plan");
+        assert_eq!(
+            plan.changed_fragments,
+            vec![
+                PathBuf::from("changes.d/first.md"),
+                PathBuf::from("changes.d/second.md"),
+            ]
+        );
+        apply_resolve_links(&repo, plan).expect("apply");
+
+        let expected_url = format!("{}/issues/1", server.base);
+        assert!(
+            fs::read_to_string(first)
+                .expect("first")
+                .contains(&expected_url)
+        );
+        assert!(
+            fs::read_to_string(second)
+                .expect("second")
+                .contains(&expected_url)
+        );
+        assert_eq!(server.finish(), vec!["HEAD /issues/1 HTTP/1.1"]);
+    }
+
+    #[test]
+    fn resolve_links_propagates_an_existing_pin_without_network_access() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "http://127.0.0.1:1/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let first = temp.path().join("changes.d/first.md");
+        let second = temp.path().join("changes.d/second.md");
+        fs::write(
+            &first,
+            "---\nlinks:\n  '#1': https://example.com/pull/1\n---\n -  First.  [[#1]]\n",
+        )
+        .expect("first fragment");
+        fs::write(&second, " -  Second.  [[#1]]\n").expect("second fragment");
+
+        let plan = plan_resolve_links(&repo, ResolveLinksOptions::default()).expect("plan");
+        assert_eq!(
+            plan.changed_fragments,
+            vec![PathBuf::from("changes.d/second.md")]
+        );
+        apply_resolve_links(&repo, plan).expect("apply");
+
+        assert!(
+            fs::read_to_string(second)
+                .expect("second")
+                .contains("https://example.com/pull/1")
+        );
+    }
+
+    #[test]
+    fn resolve_links_rejects_conflicting_existing_pins_before_network_access() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "http://127.0.0.1:1/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        fs::write(
+            temp.path().join("changes.d/first.md"),
+            "---\nlinks:\n  '#1': https://example.com/issues/1\n---\n -  First.  [[#1]]\n",
+        )
+        .expect("first fragment");
+        fs::write(
+            temp.path().join("changes.d/second.md"),
+            "---\nlinks:\n  '#1': https://example.com/pull/1\n---\n -  Second.  [[#1]]\n",
+        )
+        .expect("second fragment");
+
+        let error = plan_resolve_links(&repo, ResolveLinksOptions::default())
+            .expect_err("conflicting pins");
+
+        assert!(matches!(
+            error,
+            Error::ConflictingResolvedLinks { ref label, ref first, ref second }
+                if label == "#1"
+                    && first == "https://example.com/issues/1"
+                    && second == "https://example.com/pull/1"
+        ));
+    }
+
+    #[test]
+    fn resolved_sync_rejects_next_file_changed_after_version_snapshot() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [links]
+            "#" = "http://127.0.0.1:1/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let next = temp.path().join("changes.d/next");
+        fs::write(&next, "0.2.0\n").expect("next");
+        fs::write(
+            temp.path().join("changes.d/change.md"),
+            "---\nlinks:\n  '#1': https://example.com/pull/1\n---\n -  Fixed links.  [[#1]]\n",
+        )
+        .expect("fragment");
+        let compiled = compile_unreleased(&repo, CompileOptions::default()).expect("compile");
+        fs::write(
+            temp.path().join("CHANGES.md"),
+            format!("Changelog\n=========\n\n{}", compiled.markdown),
+        )
+        .expect("changelog");
+
+        let plan = plan_resolve_links_with_snapshot_hook(
+            &repo,
+            ResolveLinksOptions { force: true },
+            || fs::write(&next, "0.3.0\n").expect("concurrent next"),
+        )
+        .expect("plan");
+
+        let error = apply_resolve_links(&repo, plan).expect_err("stale next snapshot");
+        assert!(matches!(
+            error,
+            Error::StaleMutationPlan {
+                command: MutationCommand::ResolveLinks,
+                ref path,
+            } if path == Path::new("changes.d/next")
+        ));
+        assert_eq!(fs::read_to_string(next).expect("next"), "0.3.0\n");
+    }
+
+    proptest! {
+        #[test]
+        fn resolved_link_frontmatter_is_idempotent(
+            numbers in prop::collection::btree_set(1_u64..10_000, 0..20),
+        ) {
+            let links = numbers
+                .into_iter()
+                .map(|number| {
+                    (
+                        format!("#{number}"),
+                        format!("https://example.com/pull/{number}"),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>();
+            let source = "---\npriority: 2\nlinks:\n  stale: https://example.com/stale\n---\n -  Fixed links.\n";
+
+            let once = source_with_resolved_links(source, &links).expect("first rewrite");
+            let twice = source_with_resolved_links(&once, &links).expect("second rewrite");
+
+            prop_assert_eq!(once, twice);
+        }
+    }
+
+    #[test]
+    fn link_resolution_failure_leaves_every_fragment_unchanged() {
+        let server = TestHttpServer::spawn(vec![http_response("404 Not Found", None)]);
+        let (temp, repo) = repo_with_config(&format!(
+            "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{}/issues/{{n}}\"\n",
+            server.base
+        ));
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let path = temp.path().join("changes.d/change.md");
+        let source = " -  Fixed links.  [[#1]]\n";
+        fs::write(&path, source).expect("fragment");
+
+        let error = plan_resolve_links(&repo, ResolveLinksOptions::default())
+            .expect_err("resolution failure");
+
+        assert!(matches!(error, Error::LinkResolutionFailed { .. }));
+        assert_eq!(fs::read_to_string(path).expect("fragment"), source);
+        server.finish();
+    }
+
+    #[test]
+    fn resolved_link_plan_rejects_a_concurrent_fragment_edit() {
+        let server = TestHttpServer::spawn(vec![http_response("200 OK", None)]);
+        let (temp, repo) = repo_with_config(&format!(
+            "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{}/issues/{{n}}\"\n",
+            server.base
+        ));
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        let path = temp.path().join("changes.d/change.md");
+        fs::write(&path, " -  Fixed links.  [[#1]]\n").expect("fragment");
+        let plan = plan_resolve_links(&repo, ResolveLinksOptions::default()).expect("plan");
+        let concurrent = " -  Changed concurrently.  [[#1]]\n";
+        fs::write(&path, concurrent).expect("concurrent edit");
+
+        let error = apply_resolve_links(&repo, plan).expect_err("stale plan");
+
+        assert!(matches!(
+            error,
+            Error::StaleMutationPlan {
+                command: MutationCommand::ResolveLinks,
+                ..
+            }
+        ));
+        assert_eq!(fs::read_to_string(path).expect("fragment"), concurrent);
+        server.finish();
+    }
+
+    #[test]
     fn sync_starts_materialized_region_for_new_fragment_after_closed_release() {
         let (temp, repo) = repo_with_config("");
         fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
@@ -12765,6 +13908,60 @@ mod tests {
     }
 
     #[test]
+    fn check_allows_unpinned_links_without_network_when_resolution_is_enabled() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "http://127.0.0.1:1/issues/{n}"
+
+            [link-resolution]
+            enabled = true
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        fs::write(
+            temp.path().join("changes.d/change.md"),
+            " -  Fixed links.  [[#1]]\n",
+        )
+        .expect("fragment");
+
+        let report = check(&repo, CheckOptions::default()).expect("check");
+
+        assert!(report.is_clean());
+    }
+
+    #[test]
+    fn check_rejects_conflicting_pins_when_materialization_is_disabled() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        fs::write(
+            temp.path().join("changes.d/one.md"),
+            "---\nlinks:\n  '#1': https://example.com/pull/1\n---\n -  Fixed one. [[#1]]\n",
+        )
+        .expect("fragment");
+        fs::write(
+            temp.path().join("changes.d/two.md"),
+            "---\nlinks:\n  '#1': https://example.net/pull/1\n---\n -  Fixed two. [[#1]]\n",
+        )
+        .expect("fragment");
+
+        let error = check(&repo, CheckOptions::default()).expect_err("conflicting pins");
+
+        assert!(matches!(error, Error::ConflictingResolvedLinks { .. }));
+    }
+
+    #[test]
     fn check_reports_formatting_mismatch() {
         let (temp, repo) = repo_with_config(
             r#"
@@ -13359,6 +14556,19 @@ mod tests {
         assert_eq!(
             formatted,
             "---\npriority: -2\nowner: core\n---\n -  Added \"quotes...\" and 'apostrophes'.\n"
+        );
+    }
+
+    #[test]
+    fn format_fragment_source_sorts_resolved_links() {
+        let formatted = format_fragment_source(
+            "---\nlinks:\n  \"#2\": https://example.com/issues/2\n  \"#1\": https://example.com/pull/1\n---\n- Fixed links. [[#1], [#2]]\n",
+        )
+        .expect("format");
+
+        assert_eq!(
+            formatted,
+            "---\nlinks:\n  '#1': https://example.com/pull/1\n  '#2': https://example.com/issues/2\n---\n -  Fixed links. [[#1], [#2]]\n"
         );
     }
 

--- a/crates/sacho/src/compile.rs
+++ b/crates/sacho/src/compile.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -147,6 +147,7 @@ pub(crate) fn compile_parsed_fragments(
     let config = repo.config();
 
     validate_requested_section(repo, options.section.as_deref(), &fragments)?;
+    let resolved_links = resolved_link_overrides(&fragments)?;
     let mut items = sortable_items(fragments);
     if let Some(section) = &options.section {
         items.retain(|item| item.section.as_deref() == Some(section.as_str()));
@@ -167,7 +168,12 @@ pub(crate) fn compile_parsed_fragments(
         if section_items.is_empty() {
             continue;
         }
-        sections.push(compile_section(section_id, section_items, &config.links));
+        sections.push(compile_section(
+            section_id,
+            section_items,
+            &config.links,
+            &resolved_links,
+        ));
     }
 
     let markdown = if sections.is_empty() && !options.include_empty_region {
@@ -186,6 +192,38 @@ pub(crate) fn compile_parsed_fragments(
         sections,
         substantive_item_count,
     })
+}
+
+fn resolved_link_overrides(fragments: &[Fragment]) -> Result<BTreeMap<String, String>> {
+    let mut resolved = BTreeMap::<String, String>::new();
+    for fragment in fragments {
+        let used_labels = fragment
+            .items
+            .iter()
+            .flat_map(|item| item.references.iter())
+            .map(|reference| reference.label.as_str())
+            .collect::<BTreeSet<_>>();
+        for label in used_labels {
+            let Some(url) = fragment.links.get(label) else {
+                continue;
+            };
+            if let Some(existing) = resolved.get(label)
+                && existing != url
+            {
+                return Err(crate::Error::ConflictingResolvedLinks {
+                    label: label.to_owned(),
+                    first: existing.clone(),
+                    second: url.clone(),
+                });
+            }
+            resolved.insert(label.to_owned(), url.clone());
+        }
+    }
+    Ok(resolved)
+}
+
+pub(crate) fn validate_resolved_link_consistency(fragments: &[Fragment]) -> Result<()> {
+    resolved_link_overrides(fragments).map(drop)
 }
 
 fn validate_requested_section(
@@ -321,10 +359,12 @@ fn compile_section(
     id: Option<SectionId>,
     items: Vec<&SortableItem>,
     link_templates: &IndexMap<ReferenceSigil, UrlTemplate>,
+    resolved_links: &BTreeMap<String, String>,
 ) -> CompiledSection {
     let references = compile_references(
         items.iter().flat_map(|item| item.references.iter()),
         link_templates,
+        resolved_links,
     );
     let mut markdown = String::new();
     if let Some(id) = &id {
@@ -355,6 +395,7 @@ fn compile_section(
 fn compile_references<'a>(
     references: impl Iterator<Item = &'a ReferenceUse>,
     link_templates: &IndexMap<ReferenceSigil, UrlTemplate>,
+    resolved_links: &BTreeMap<String, String>,
 ) -> Vec<CompiledReference> {
     let sigil_order = link_templates
         .keys()
@@ -377,10 +418,15 @@ fn compile_references<'a>(
                 .iter()
                 .find(|(sigil, _)| sigil.as_str() == reference.sigil)
                 .map(|(_, template)| CompiledReference {
+                    url: resolved_links
+                        .get(&reference.label)
+                        .cloned()
+                        .unwrap_or_else(|| {
+                            template
+                                .as_str()
+                                .replace("{n}", &reference.number.to_string())
+                        }),
                     label: reference.label,
-                    url: template
-                        .as_str()
-                        .replace("{n}", &reference.number.to_string()),
                 })
         })
         .collect()
@@ -641,6 +687,59 @@ mod tests {
         );
         assert_eq!(compiled.sections[0].id, None);
         assert_eq!(compiled.sections[0].references.len(), 1);
+    }
+
+    #[test]
+    fn resolved_frontmatter_link_overrides_the_template() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        fs::write(
+            temp.path().join("changes.d/change.md"),
+            "---\nlinks:\n  \"#2\": https://example.com/pull/2\n---\n -  Fixed thing.  [[#2]]\n",
+        )
+        .expect("fragment");
+
+        let compiled = compile_unreleased(&repo, CompileOptions::default()).expect("compile");
+
+        assert!(
+            compiled
+                .markdown
+                .contains("[#2]: https://example.com/pull/2")
+        );
+    }
+
+    #[test]
+    fn rejects_conflicting_resolved_links_across_fragments() {
+        let (temp, repo) = repo_with_config(
+            r##"
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        fs::write(
+            temp.path().join("changes.d/one.md"),
+            "---\nlinks:\n  \"#2\": https://example.com/pull/2\n---\n -  Fixed one.  [[#2]]\n",
+        )
+        .expect("fragment");
+        fs::write(
+            temp.path().join("changes.d/two.md"),
+            "---\nlinks:\n  \"#2\": https://example.net/pull/2\n---\n -  Fixed two.  [[#2]]\n",
+        )
+        .expect("fragment");
+
+        let error = compile_unreleased(&repo, CompileOptions::default())
+            .expect_err("conflicting link overrides");
+
+        assert!(matches!(
+            error,
+            crate::Error::ConflictingResolvedLinks { ref label, .. } if label == "#2"
+        ));
     }
 
     #[test]

--- a/crates/sacho/src/config.rs
+++ b/crates/sacho/src/config.rs
@@ -24,6 +24,10 @@ pub struct Config {
     #[serde(default)]
     pub links: IndexMap<ReferenceSigil, UrlTemplate>,
 
+    /// HTTP redirect resolution settings for reference links.
+    #[serde(default)]
+    pub link_resolution: LinkResolutionConfig,
+
     /// Version-control integration settings.
     #[serde(default)]
     pub vcs: VcsConfig,
@@ -261,6 +265,14 @@ impl UrlTemplate {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+}
+
+/// HTTP redirect resolution settings for reference links.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct LinkResolutionConfig {
+    /// Whether supported commands resolve unpinned links by default.
+    pub enabled: bool,
 }
 
 /// Version-control integration configuration.
@@ -518,6 +530,7 @@ mod tests {
                         ..FragmentsConfig::default()
                     },
                     links: link_map,
+                    link_resolution: LinkResolutionConfig::default(),
                     vcs: VcsConfig::default(),
                     check: CheckConfig::default(),
                     sections: unique_sections,
@@ -531,8 +544,29 @@ mod tests {
 
         assert_eq!(config.changelog.path, PathBuf::from("CHANGES.md"));
         assert_eq!(config.fragments.directory, PathBuf::from("changes.d"));
+        assert!(!config.link_resolution.enabled);
         assert_eq!(config.vcs.preset, VcsPreset::Git);
         assert!(config.vcs.commands.is_empty());
+    }
+
+    #[test]
+    fn parses_link_resolution_policy_without_changing_link_templates() {
+        let config = Config::parse(
+            r##"
+            [links]
+            "#" = "https://example.com/issues/{n}"
+
+            [link-resolution]
+            enabled = true
+            "##,
+        )
+        .expect("link resolution config");
+
+        assert!(config.link_resolution.enabled);
+        assert_eq!(
+            config.links[&ReferenceSigil::new("#")].as_str(),
+            "https://example.com/issues/{n}"
+        );
     }
 
     #[test]

--- a/crates/sacho/src/error.rs
+++ b/crates/sacho/src/error.rs
@@ -3,6 +3,58 @@ use std::path::PathBuf;
 use crate::changelog::ChangelogError;
 use snafu::Snafu;
 
+/// Removes HTTP userinfo before a URL is stored in an error.
+pub(crate) fn redact_url_credentials(value: &str) -> String {
+    let Ok(mut url) = url::Url::parse(value) else {
+        return String::from("<invalid URL>");
+    };
+    if url.username().is_empty() && url.password().is_none() {
+        return value.to_owned();
+    }
+    if url.set_password(None).is_err() || url.set_username("").is_err() {
+        return String::from("<redacted URL>");
+    }
+    url.into()
+}
+
+#[cfg(test)]
+mod credential_redaction_tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn redacts_generated_http_userinfo(
+            username in "[A-Za-z0-9]{1,16}",
+            password in "[A-Za-z0-9]{1,16}",
+            number in any::<u64>(),
+        ) {
+            let source =
+                format!("https://{username}:{password}@example.com/issues/{number}");
+            let redacted = redact_url_credentials(&source);
+            let parsed = url::Url::parse(&redacted).expect("redacted URL");
+            let credentials = format!("{username}:{password}@");
+            let path = format!("/issues/{number}");
+
+            prop_assert!(parsed.username().is_empty());
+            prop_assert!(parsed.password().is_none());
+            prop_assert!(!redacted.contains(&credentials));
+            prop_assert!(redacted.ends_with(&path));
+        }
+    }
+
+    #[test]
+    fn replaces_unparseable_urls_instead_of_echoing_them() {
+        let source = "https://user:secret@";
+
+        let redacted = redact_url_credentials(source);
+
+        assert_eq!(redacted, "<invalid URL>");
+        assert!(!redacted.contains("secret"));
+    }
+}
+
 /// Built-in command whose multi-file repository mutation is transactional.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MutationCommand {
@@ -17,6 +69,9 @@ pub enum MutationCommand {
 
     /// The `import-unreleased` command.
     ImportUnreleased,
+
+    /// The `resolve-links` command or a resolving synchronization.
+    ResolveLinks,
 }
 
 impl std::fmt::Display for MutationCommand {
@@ -26,6 +81,7 @@ impl std::fmt::Display for MutationCommand {
             Self::Format => "fmt",
             Self::Carry => "carry",
             Self::ImportUnreleased => "import-unreleased",
+            Self::ResolveLinks => "resolve-links",
         })
     }
 }
@@ -37,6 +93,30 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {
+    /// An unpinned reference URL could not be resolved through HTTP redirects.
+    #[snafu(display("failed to resolve reference {label:?} from {url:?}: {reason}"))]
+    LinkResolutionFailed {
+        /// Complete reference label being resolved.
+        label: String,
+        /// Expanded URL template sent to the server.
+        url: String,
+        /// HTTP or transport failure.
+        reason: String,
+    },
+
+    /// Two fragments pin the same reference label to different URLs.
+    #[snafu(display(
+        "reference label {label:?} has conflicting resolved URLs {first:?} and {second:?}"
+    ))]
+    ConflictingResolvedLinks {
+        /// Complete reference label with conflicting overrides.
+        label: String,
+        /// First resolved URL encountered.
+        first: String,
+        /// Conflicting resolved URL.
+        second: String,
+    },
+
     /// The current Sacho executable could not be located for repository integration.
     #[snafu(display("failed to determine the current Sacho executable: {source}"))]
     CurrentExecutable {
@@ -828,6 +908,26 @@ pub enum FragmentError {
     Frontmatter {
         /// Underlying YAML parser error.
         source: serde_yaml_ng::Error,
+    },
+
+    /// A resolved reference URL in fragment frontmatter is not safe to request.
+    #[snafu(display("invalid resolved link {label:?} = {url:?}: {reason}"))]
+    InvalidResolvedLink {
+        /// Complete reference label whose URL is invalid.
+        label: String,
+        /// Invalid URL value.
+        url: String,
+        /// Validation failure.
+        reason: String,
+    },
+
+    /// A resolved-link frontmatter key is malformed, unconfigured, or unused.
+    #[snafu(display("invalid resolved link label {label:?}: {reason}"))]
+    InvalidResolvedLinkLabel {
+        /// Frontmatter key that cannot act as a pin for this fragment.
+        label: String,
+        /// Validation failure.
+        reason: String,
     },
 
     /// The fragment Markdown did not match Sacho's structural constraints.

--- a/crates/sacho/src/fragment.rs
+++ b/crates/sacho/src/fragment.rs
@@ -9,13 +9,13 @@ use comrak::{Arena, Options as ComrakOptions, parse_document};
 use indexmap::IndexMap;
 use serde::Deserialize;
 use snafu::ResultExt;
-use url::Url;
 
 use crate::config::{ReferenceSigil, UrlTemplate};
 use crate::error::{
     FragmentError, FrontmatterSnafu, ReadFileSnafu, Result, UnclosedFrontmatterSnafu,
     UnknownReferenceSnafu, redact_url_credentials,
 };
+use crate::link_resolution::validate_http_url;
 use crate::repo::Repository;
 
 /// Parsed changelog fragment.
@@ -472,26 +472,13 @@ pub(crate) fn validate_resolved_link(
     label: &str,
     value: &str,
 ) -> std::result::Result<(), FragmentError> {
-    let url = Url::parse(value).map_err(|source| FragmentError::InvalidResolvedLink {
-        label: label.to_owned(),
-        url: redact_url_credentials(value),
-        reason: source.to_string(),
-    })?;
-    if !matches!(url.scheme(), "http" | "https") {
-        return Err(FragmentError::InvalidResolvedLink {
+    validate_http_url(value)
+        .map(drop)
+        .map_err(|reason| FragmentError::InvalidResolvedLink {
             label: label.to_owned(),
             url: redact_url_credentials(value),
-            reason: String::from("scheme must be http or https"),
-        });
-    }
-    if !url.username().is_empty() || url.password().is_some() {
-        return Err(FragmentError::InvalidResolvedLink {
-            label: label.to_owned(),
-            url: redact_url_credentials(value),
-            reason: String::from("userinfo is not allowed"),
-        });
-    }
-    Ok(())
+            reason,
+        })
 }
 
 fn comrak_options() -> ComrakOptions<'static> {

--- a/crates/sacho/src/fragment.rs
+++ b/crates/sacho/src/fragment.rs
@@ -9,11 +9,12 @@ use comrak::{Arena, Options as ComrakOptions, parse_document};
 use indexmap::IndexMap;
 use serde::Deserialize;
 use snafu::ResultExt;
+use url::Url;
 
 use crate::config::{ReferenceSigil, UrlTemplate};
 use crate::error::{
     FragmentError, FrontmatterSnafu, ReadFileSnafu, Result, UnclosedFrontmatterSnafu,
-    UnknownReferenceSnafu,
+    UnknownReferenceSnafu, redact_url_credentials,
 };
 use crate::repo::Repository;
 
@@ -28,6 +29,9 @@ pub struct Fragment {
 
     /// Sort priority read from frontmatter.
     pub priority: i32,
+
+    /// Resolved reference URLs pinned in frontmatter.
+    pub links: BTreeMap<String, String>,
 
     /// Items contributed by the fragment.
     pub items: Vec<FragmentItem>,
@@ -60,6 +64,9 @@ pub struct FragmentItem {
 pub struct Frontmatter {
     /// Sort priority for all items in the fragment.
     pub priority: i32,
+
+    /// Resolved reference URLs keyed by complete reference label.
+    pub links: BTreeMap<String, String>,
 
     /// Frontmatter keys Sacho does not understand.
     pub unknown_keys: Vec<String>,
@@ -137,6 +144,8 @@ pub enum DiscoveryWarning {
 #[derive(Debug, Deserialize)]
 struct RawFrontmatter {
     priority: Option<i32>,
+    #[serde(default)]
+    links: BTreeMap<String, String>,
     #[serde(flatten)]
     extra: BTreeMap<String, serde_yaml_ng::Value>,
 }
@@ -294,14 +303,54 @@ pub fn parse_fragment(
             references,
         });
     }
+    validate_resolved_link_labels(&frontmatter.links, &items, link_templates)?;
 
     Ok(Fragment {
         path,
         section,
         priority: frontmatter.priority,
+        links: frontmatter.links,
         items,
         warnings,
     })
+}
+
+fn validate_resolved_link_labels(
+    links: &BTreeMap<String, String>,
+    items: &[FragmentItem],
+    link_templates: &IndexMap<ReferenceSigil, UrlTemplate>,
+) -> std::result::Result<(), FragmentError> {
+    for label in links.keys() {
+        if !is_complete_reference_label(label, link_templates) {
+            return Err(FragmentError::InvalidResolvedLinkLabel {
+                label: label.clone(),
+                reason: String::from(
+                    "must be a configured link sigil followed by a reference number",
+                ),
+            });
+        }
+        let is_used = items
+            .iter()
+            .flat_map(|item| &item.references)
+            .any(|reference| reference.label == *label);
+        if !is_used {
+            return Err(FragmentError::InvalidResolvedLinkLabel {
+                label: label.clone(),
+                reason: String::from("label is not used by this fragment"),
+            });
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn is_complete_reference_label(
+    label: &str,
+    link_templates: &IndexMap<ReferenceSigil, UrlTemplate>,
+) -> bool {
+    matches!(
+        parse_reference_label(label, link_templates),
+        Ok(Some(reference)) if reference.label == label
+    )
 }
 
 fn collect_markdown_files(
@@ -408,11 +457,41 @@ impl Frontmatter {
             return Ok(Self::default());
         }
         let raw: RawFrontmatter = serde_yaml_ng::from_str(yaml).context(FrontmatterSnafu)?;
+        for (label, value) in &raw.links {
+            validate_resolved_link(label, value)?;
+        }
         Ok(Self {
             priority: raw.priority.unwrap_or_default(),
+            links: raw.links,
             unknown_keys: raw.extra.into_keys().collect(),
         })
     }
+}
+
+pub(crate) fn validate_resolved_link(
+    label: &str,
+    value: &str,
+) -> std::result::Result<(), FragmentError> {
+    let url = Url::parse(value).map_err(|source| FragmentError::InvalidResolvedLink {
+        label: label.to_owned(),
+        url: redact_url_credentials(value),
+        reason: source.to_string(),
+    })?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(FragmentError::InvalidResolvedLink {
+            label: label.to_owned(),
+            url: redact_url_credentials(value),
+            reason: String::from("scheme must be http or https"),
+        });
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(FragmentError::InvalidResolvedLink {
+            label: label.to_owned(),
+            url: redact_url_credentials(value),
+            reason: String::from("userinfo is not allowed"),
+        });
+    }
+    Ok(())
 }
 
 fn comrak_options() -> ComrakOptions<'static> {
@@ -672,6 +751,19 @@ mod tests {
     }
 
     #[test]
+    fn treats_null_resolved_links_as_empty() {
+        let fragment = parse_fragment(
+            "change.md".into(),
+            "---\nlinks:\n---\n -  Added thing.\n",
+            None,
+            &links(),
+        )
+        .expect("fragment");
+
+        assert!(fragment.links.is_empty());
+    }
+
+    #[test]
     fn parses_empty_frontmatter() {
         let fragment = parse_fragment(
             "change.md".into(),
@@ -682,6 +774,106 @@ mod tests {
         .expect("fragment");
 
         assert_eq!(fragment.priority, 0);
+    }
+
+    #[test]
+    fn parses_resolved_links_from_frontmatter() {
+        let fragment = parse_fragment(
+            "change.md".into(),
+            "---\nlinks:\n  \"#123\": https://example.com/pull/123\n---\n -  Fixed thing.  [[#123]]\n",
+            None,
+            &links(),
+        )
+        .expect("fragment");
+
+        assert_eq!(
+            fragment.links,
+            BTreeMap::from([(
+                String::from("#123"),
+                String::from("https://example.com/pull/123")
+            )])
+        );
+        assert!(fragment.warnings.is_empty());
+    }
+
+    #[test]
+    fn rejects_malformed_resolved_link_labels() {
+        let error = parse_fragment(
+            "change.md".into(),
+            "---\nlinks:\n  \"#l\": https://example.com/pull/1\n---\n -  Fixed thing.  [[#1]]\n",
+            None,
+            &links(),
+        )
+        .expect_err("resolved link labels must be complete configured references");
+
+        assert!(error.to_string().contains("resolved link label"));
+        assert!(error.to_string().contains("#l"));
+    }
+
+    proptest! {
+        #[test]
+        fn resolved_link_labels_must_be_used_by_the_fragment(
+            pinned in 0_u64..10_000,
+            used in 0_u64..10_000,
+        ) {
+            let source = format!(
+                "---\nlinks:\n  \"#{pinned}\": https://example.com/pull/{pinned}\n---\n -  Fixed thing.  [[#{used}]]\n"
+            );
+            let result = parse_fragment("change.md".into(), &source, None, &links());
+
+            if pinned == used {
+                prop_assert!(result.is_ok());
+            } else {
+                let error = result.expect_err("unused resolved link labels must fail");
+                prop_assert!(error.to_string().contains("resolved link label"));
+                prop_assert!(error.to_string().contains("not used"));
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_non_http_resolved_link() {
+        let error = parse_fragment(
+            "change.md".into(),
+            "---\nlinks:\n  \"#123\": file:///tmp/123\n---\n -  Fixed thing.  [[#123]]\n",
+            None,
+            &links(),
+        )
+        .expect_err("resolved links must be HTTP URLs");
+
+        assert!(matches!(
+            error,
+            FragmentError::InvalidResolvedLink { ref label, .. } if label == "#123"
+        ));
+    }
+
+    #[test]
+    fn rejects_resolved_links_with_username_or_password() {
+        for url in [
+            "https://user:secret@example.com/pull/123",
+            "https://:secret@example.com/pull/123",
+        ] {
+            let source =
+                format!("---\nlinks:\n  \"#123\": {url}\n---\n -  Fixed thing.  [[#123]]\n");
+            let error = parse_fragment("change.md".into(), &source, None, &links())
+                .expect_err("resolved links must not contain userinfo");
+
+            assert!(matches!(
+                error,
+                FragmentError::InvalidResolvedLink { ref label, ref reason, .. }
+                    if label == "#123" && reason.contains("userinfo")
+            ));
+            let FragmentError::InvalidResolvedLink {
+                url: reported_url, ..
+            } = &error
+            else {
+                unreachable!("checked above");
+            };
+            assert!(!reported_url.contains("user:secret"));
+            assert!(!reported_url.contains(":secret@"));
+            assert!(!error.to_string().contains("user:secret"));
+            assert!(!error.to_string().contains(":secret@"));
+        }
     }
 
     #[test]

--- a/crates/sacho/src/lib.rs
+++ b/crates/sacho/src/lib.rs
@@ -20,6 +20,8 @@ pub mod diagnostic;
 pub mod error;
 /// Fragment discovery, parsing, and validation types.
 pub mod fragment;
+/// Reference-link redirect resolution types.
+pub mod link_resolution;
 /// Markdown formatting adapter types.
 pub mod markdown;
 /// Changelog merge driver types.
@@ -33,8 +35,9 @@ mod repository_url;
 pub mod vcs;
 
 pub use crate::config::{
-    ChangelogConfig, CheckConfig, Config, FragmentsConfig, ReferenceSigil, RegionDetection,
-    SectionConfig, UrlTemplate, VcsCommand, VcsCommandOverrides, VcsConfig, VcsPreset, VcsQuery,
+    ChangelogConfig, CheckConfig, Config, FragmentsConfig, LinkResolutionConfig, ReferenceSigil,
+    RegionDetection, SectionConfig, UrlTemplate, VcsCommand, VcsCommandOverrides, VcsConfig,
+    VcsPreset, VcsQuery,
 };
 pub use crate::error::{ConfigError, Error, FragmentError, MutationCommand, Result};
 pub use crate::repo::Repository;

--- a/crates/sacho/src/link_resolution.rs
+++ b/crates/sacho/src/link_resolution.rs
@@ -1,0 +1,517 @@
+//! HTTP redirect resolution for reference links.
+
+use std::time::Duration;
+
+use ureq::Agent;
+use url::Url;
+
+use crate::config::Config;
+use crate::error::{Error, Result, redact_url_credentials};
+
+const MAX_REDIRECTS: usize = 10;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Controls whether a command follows redirects for unpinned reference links.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum LinkResolutionPolicy {
+    /// Never make network requests for reference links.
+    #[default]
+    Never,
+
+    /// Follow the repository's `[link-resolution]` setting.
+    Configured,
+
+    /// Resolve every unpinned reference link.
+    Always,
+}
+
+impl LinkResolutionPolicy {
+    /// Returns whether this policy enables network resolution for a repository.
+    pub fn is_enabled(self, config: &Config) -> bool {
+        match self {
+            Self::Never => false,
+            Self::Configured => config.link_resolution.enabled,
+            Self::Always => true,
+        }
+    }
+}
+
+pub(crate) fn is_http_reference_url(value: &str) -> bool {
+    matches!(
+        Url::parse(value),
+        Ok(url) if matches!(url.scheme(), "http" | "https")
+    )
+}
+
+/// Resolves one expanded reference URL and returns its final effective URL.
+pub fn resolve_reference_url(label: &str, source_url: &str) -> Result<String> {
+    ReferenceUrlResolver::new().resolve(label, source_url)
+}
+
+pub(crate) struct ReferenceUrlResolver {
+    agent: Agent,
+}
+
+impl ReferenceUrlResolver {
+    pub(crate) fn new() -> Self {
+        let agent: Agent = Agent::config_builder()
+            .max_redirects(0)
+            .max_redirects_will_error(false)
+            .http_status_as_error(false)
+            .timeout_global(Some(REQUEST_TIMEOUT))
+            .user_agent(format!("sacho/{}", env!("CARGO_PKG_VERSION")))
+            .build()
+            .into();
+        Self { agent }
+    }
+
+    pub(crate) fn resolve(&self, label: &str, source_url: &str) -> Result<String> {
+        let (response, resolved) =
+            request_following_redirects(&self.agent, label, source_url, RequestMethod::Head)?;
+        let status = response.status().as_u16();
+        if matches!(status, 405 | 501) {
+            let (response, resolved) = request_following_redirects(
+                &self.agent,
+                label,
+                source_url,
+                RequestMethod::RangedGet,
+            )?;
+            return resolved_response_url(label, source_url, response, resolved);
+        }
+        resolved_response_url(label, source_url, response, resolved)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RequestMethod {
+    Head,
+    RangedGet,
+}
+
+fn request_following_redirects(
+    agent: &Agent,
+    label: &str,
+    source_url: &str,
+    method: RequestMethod,
+) -> Result<(ureq::http::Response<ureq::Body>, Url)> {
+    let mut current = validate_request_url(label, source_url)?;
+    for redirect_count in 0..=MAX_REDIRECTS {
+        let response = match method {
+            RequestMethod::Head => agent.head(current.as_str()).call(),
+            RequestMethod::RangedGet => agent
+                .get(current.as_str())
+                .header("Range", "bytes=0-0")
+                .call(),
+        }
+        .map_err(|source| resolution_error(label, current.as_str(), source))?;
+        let status = response.status().as_u16();
+        if !matches!(status, 301 | 302 | 303 | 307 | 308) {
+            return Ok((response, current));
+        }
+        if redirect_count == MAX_REDIRECTS {
+            return Err(link_resolution_failure(
+                label,
+                source_url,
+                format!("more than {MAX_REDIRECTS} redirects"),
+            ));
+        }
+        let location = response
+            .headers()
+            .get("Location")
+            .ok_or_else(|| {
+                link_resolution_failure(
+                    label,
+                    current.as_str(),
+                    format!("HTTP redirect status {status} has no Location header"),
+                )
+            })?
+            .to_str()
+            .map_err(|source| {
+                link_resolution_failure(
+                    label,
+                    current.as_str(),
+                    format!("invalid Location header: {source}"),
+                )
+            })?;
+        let next = current.join(location).map_err(|source| {
+            link_resolution_failure(label, location, format!("invalid redirect URL: {source}"))
+        })?;
+        validate_request_url(label, next.as_str())?;
+        current = next;
+    }
+    unreachable!("the redirect loop always returns")
+}
+
+fn resolved_response_url(
+    label: &str,
+    source_url: &str,
+    response: ureq::http::Response<ureq::Body>,
+    resolved: Url,
+) -> Result<String> {
+    if !response.status().is_success() {
+        return Err(link_resolution_failure(
+            label,
+            source_url,
+            format!("HTTP status {}", response.status().as_u16()),
+        ));
+    }
+    Ok(resolved.into())
+}
+
+fn validate_request_url(label: &str, value: &str) -> Result<Url> {
+    let url = Url::parse(value)
+        .map_err(|source| link_resolution_failure(label, value, source.to_string()))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(link_resolution_failure(
+            label,
+            value,
+            "scheme must be http or https",
+        ));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(link_resolution_failure(
+            label,
+            value,
+            "userinfo is not allowed",
+        ));
+    }
+    Ok(url)
+}
+
+fn resolution_error(label: &str, url: &str, source: ureq::Error) -> Error {
+    link_resolution_failure(label, url, source.to_string())
+}
+
+fn link_resolution_failure(label: &str, url: &str, reason: impl Into<String>) -> Error {
+    Error::LinkResolutionFailed {
+        label: label.to_owned(),
+        url: redact_url_credentials(url),
+        reason: reason.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{BufRead, BufReader, Read, Write};
+    use std::net::{SocketAddr, TcpListener, TcpStream};
+    use std::thread::{self, JoinHandle};
+    use std::time::{Duration, Instant};
+
+    use super::*;
+
+    struct TestServer {
+        base: String,
+        address: SocketAddr,
+        response_count: usize,
+        handle: Option<thread::JoinHandle<Vec<String>>>,
+    }
+
+    struct ConnectionCountingServer {
+        base: String,
+        handle: Option<JoinHandle<(usize, Vec<String>)>>,
+    }
+
+    impl ConnectionCountingServer {
+        fn spawn(expected_requests: usize) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+            listener
+                .set_nonblocking(true)
+                .expect("nonblocking listener");
+            let address = listener.local_addr().expect("address");
+            let base = format!("http://{address}");
+            let handle = thread::spawn(move || {
+                let deadline = Instant::now() + Duration::from_secs(5);
+                let mut connections = Vec::<(TcpStream, Vec<u8>)>::new();
+                let mut accepted = 0;
+                let mut requests = Vec::new();
+
+                while requests.len() < expected_requests {
+                    loop {
+                        match listener.accept() {
+                            Ok((stream, _)) => {
+                                stream.set_nonblocking(true).expect("nonblocking stream");
+                                connections.push((stream, Vec::new()));
+                                accepted += 1;
+                            }
+                            Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => break,
+                            Err(source) => panic!("accept connection: {source}"),
+                        }
+                    }
+
+                    for (stream, buffer) in &mut connections {
+                        let mut chunk = [0_u8; 1024];
+                        loop {
+                            match stream.read(&mut chunk) {
+                                Ok(0) => break,
+                                Ok(count) => buffer.extend_from_slice(&chunk[..count]),
+                                Err(source) if source.kind() == std::io::ErrorKind::WouldBlock => {
+                                    break;
+                                }
+                                Err(source) => panic!("read request: {source}"),
+                            }
+                        }
+
+                        while let Some(header_end) =
+                            buffer.windows(4).position(|window| window == b"\r\n\r\n")
+                        {
+                            let request = buffer.drain(..header_end + 4).collect::<Vec<_>>();
+                            let request = String::from_utf8(request).expect("HTTP request");
+                            requests.push(request.lines().next().expect("request line").to_owned());
+                            stream
+                                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                                .expect("response");
+                        }
+                    }
+
+                    assert!(
+                        Instant::now() < deadline,
+                        "received {} of {expected_requests} requests",
+                        requests.len()
+                    );
+                    thread::sleep(Duration::from_millis(1));
+                }
+
+                (accepted, requests)
+            });
+            Self {
+                base,
+                handle: Some(handle),
+            }
+        }
+
+        fn finish(mut self) -> (usize, Vec<String>) {
+            self.handle.take().expect("handle").join().expect("server")
+        }
+    }
+
+    impl TestServer {
+        fn spawn(responses: Vec<String>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+            let address = listener.local_addr().expect("address");
+            let base = format!("http://{address}");
+            let response_count = responses.len();
+            let handle = thread::spawn(move || {
+                let mut requests = Vec::new();
+                for response in responses {
+                    let (mut stream, _) = listener.accept().expect("connection");
+                    requests.push(read_request_line(&stream));
+                    stream.write_all(response.as_bytes()).expect("response");
+                }
+                requests
+            });
+            Self {
+                base,
+                address,
+                response_count,
+                handle: Some(handle),
+            }
+        }
+
+        fn finish(mut self) -> Vec<String> {
+            wake_server(self.address, self.response_count);
+            self.handle.take().expect("handle").join().expect("server")
+        }
+    }
+
+    impl Drop for TestServer {
+        fn drop(&mut self) {
+            let Some(handle) = self.handle.take() else {
+                return;
+            };
+            wake_server(self.address, self.response_count);
+            handle.join().expect("server");
+        }
+    }
+
+    fn wake_server(address: SocketAddr, attempts: usize) {
+        for _ in 0..attempts {
+            let Ok(mut stream) = TcpStream::connect(address) else {
+                break;
+            };
+            stream
+                .write_all(b"HEAD /test-server-shutdown HTTP/1.1\r\n\r\n")
+                .expect("shutdown request");
+        }
+    }
+
+    fn read_request_line(stream: &TcpStream) -> String {
+        BufReader::new(stream)
+            .lines()
+            .next()
+            .expect("request line")
+            .expect("request line contents")
+    }
+
+    fn response(status: &str, headers: &[(&str, &str)]) -> String {
+        let mut output = format!("HTTP/1.1 {status}\r\nConnection: close\r\nContent-Length: 0\r\n");
+        for (name, value) in headers {
+            output.push_str(name);
+            output.push_str(": ");
+            output.push_str(value);
+            output.push_str("\r\n");
+        }
+        output.push_str("\r\n");
+        output
+    }
+
+    #[test]
+    fn follows_the_complete_redirect_chain() {
+        let server = TestServer::spawn(vec![
+            response("302 Found", &[("Location", "/discussion/42")]),
+            response(
+                "301 Moved Permanently",
+                &[("Location", "/org/discussion/42")],
+            ),
+            response("200 OK", &[]),
+        ]);
+        let source = format!("{}/issues/42", server.base);
+
+        let resolved = resolve_reference_url("#42", &source).expect("resolved URL");
+
+        assert_eq!(resolved, format!("{}/org/discussion/42", server.base));
+        assert_eq!(
+            server.finish(),
+            vec![
+                "HEAD /issues/42 HTTP/1.1",
+                "HEAD /discussion/42 HTTP/1.1",
+                "HEAD /org/discussion/42 HTTP/1.1",
+            ]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_a_ranged_get_when_head_is_unsupported() {
+        let server = TestServer::spawn(vec![
+            response("405 Method Not Allowed", &[]),
+            response("200 OK", &[]),
+        ]);
+        let source = format!("{}/issues/7", server.base);
+
+        let resolved = resolve_reference_url("#7", &source).expect("resolved URL");
+
+        assert_eq!(resolved, source);
+        assert_eq!(
+            server.finish(),
+            vec!["HEAD /issues/7 HTTP/1.1", "GET /issues/7 HTTP/1.1"]
+        );
+    }
+
+    #[test]
+    fn resolver_reuses_a_connection_across_multiple_urls() {
+        let server = ConnectionCountingServer::spawn(2);
+        let resolver = ReferenceUrlResolver::new();
+
+        resolver
+            .resolve("#1", &format!("{}/issues/1", server.base))
+            .expect("first URL");
+        resolver
+            .resolve("#2", &format!("{}/issues/2", server.base))
+            .expect("second URL");
+
+        assert_eq!(
+            server.finish(),
+            (
+                1,
+                vec![
+                    String::from("HEAD /issues/1 HTTP/1.1"),
+                    String::from("HEAD /issues/2 HTTP/1.1"),
+                ],
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_unsuccessful_final_status() {
+        let server = TestServer::spawn(vec![response("404 Not Found", &[])]);
+        let source = format!("{}/issues/9", server.base);
+
+        let error = resolve_reference_url("#9", &source).expect_err("404 must fail");
+
+        assert!(matches!(
+            error,
+            Error::LinkResolutionFailed { ref label, ref reason, .. }
+                if label == "#9" && reason.contains("404")
+        ));
+        server.finish();
+    }
+
+    #[test]
+    fn rejects_redirect_without_location() {
+        let server = TestServer::spawn(vec![response("302 Found", &[])]);
+        let source = format!("{}/issues/10", server.base);
+
+        let error = resolve_reference_url("#10", &source).expect_err("Location is required");
+
+        assert!(matches!(
+            error,
+            Error::LinkResolutionFailed { ref label, ref reason, .. }
+                if label == "#10" && reason.contains("no Location")
+        ));
+        assert_eq!(server.finish(), vec!["HEAD /issues/10 HTTP/1.1"]);
+    }
+
+    #[test]
+    fn rejects_more_than_ten_redirects() {
+        let server = TestServer::spawn(
+            (0..=MAX_REDIRECTS)
+                .map(|_| response("302 Found", &[("Location", "/loop")]))
+                .collect(),
+        );
+        let source = format!("{}/loop", server.base);
+
+        let error = resolve_reference_url("#10", &source).expect_err("redirect limit");
+
+        assert!(matches!(
+            error,
+            Error::LinkResolutionFailed { ref label, ref reason, .. }
+                if label == "#10" && reason.contains("more than 10 redirects")
+        ));
+        assert_eq!(server.finish().len(), MAX_REDIRECTS + 1);
+    }
+
+    #[test]
+    fn rejects_credentials_before_making_a_request() {
+        for source in [
+            "http://user:secret@127.0.0.1:1/issues/10",
+            "http://:secret@127.0.0.1:1/issues/10",
+        ] {
+            let error = resolve_reference_url("#10", source).expect_err("userinfo must fail");
+
+            assert!(matches!(
+                error,
+                Error::LinkResolutionFailed { ref label, ref reason, .. }
+                    if label == "#10" && reason.contains("userinfo")
+            ));
+            let Error::LinkResolutionFailed { url, .. } = &error else {
+                unreachable!("checked above");
+            };
+            assert!(!url.contains("user:secret"));
+            assert!(!url.contains(":secret@"));
+            assert!(!error.to_string().contains("user:secret"));
+            assert!(!error.to_string().contains(":secret@"));
+        }
+    }
+
+    #[test]
+    fn rejects_redirect_userinfo_before_requesting_the_target() {
+        let target = TestServer::spawn(vec![response("200 OK", &[])]);
+        let target_authority = target.base.strip_prefix("http://").expect("authority");
+        let location = format!("http://user:secret@{target_authority}/private");
+        let source = TestServer::spawn(vec![response(
+            "302 Found",
+            &[("Location", location.as_str())],
+        )]);
+        let source_url = format!("{}/issues/11", source.base);
+
+        let error = resolve_reference_url("#11", &source_url)
+            .expect_err("redirect userinfo must fail before the target request");
+
+        assert!(matches!(
+            error,
+            Error::LinkResolutionFailed { ref label, ref reason, .. }
+                if label == "#11" && reason.contains("userinfo")
+        ));
+        assert_eq!(source.finish(), vec!["HEAD /issues/11 HTTP/1.1"]);
+        assert_eq!(target.finish(), vec!["HEAD /test-server-shutdown HTTP/1.1"]);
+    }
+}

--- a/crates/sacho/src/link_resolution.rs
+++ b/crates/sacho/src/link_resolution.rs
@@ -43,6 +43,17 @@ pub(crate) fn is_http_reference_url(value: &str) -> bool {
     )
 }
 
+pub(crate) fn validate_http_url(value: &str) -> std::result::Result<Url, String> {
+    let url = Url::parse(value).map_err(|source| source.to_string())?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(String::from("scheme must be http or https"));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(String::from("userinfo is not allowed"));
+    }
+    Ok(url)
+}
+
 /// Resolves one expanded reference URL and returns its final effective URL.
 pub fn resolve_reference_url(label: &str, source_url: &str) -> Result<String> {
     ReferenceUrlResolver::new().resolve(label, source_url)
@@ -136,7 +147,8 @@ fn request_following_redirects(
         let next = current.join(location).map_err(|source| {
             link_resolution_failure(label, location, format!("invalid redirect URL: {source}"))
         })?;
-        validate_request_url(label, next.as_str())?;
+        let next = validate_request_url(label, next.as_str())?;
+        validate_redirect_transition(label, &current, &next)?;
         current = next;
     }
     unreachable!("the redirect loop always returns")
@@ -159,23 +171,18 @@ fn resolved_response_url(
 }
 
 fn validate_request_url(label: &str, value: &str) -> Result<Url> {
-    let url = Url::parse(value)
-        .map_err(|source| link_resolution_failure(label, value, source.to_string()))?;
-    if !matches!(url.scheme(), "http" | "https") {
+    validate_http_url(value).map_err(|reason| link_resolution_failure(label, value, reason))
+}
+
+fn validate_redirect_transition(label: &str, current: &Url, next: &Url) -> Result<()> {
+    if current.scheme() == "https" && next.scheme() == "http" {
         return Err(link_resolution_failure(
             label,
-            value,
-            "scheme must be http or https",
+            next.as_str(),
+            "HTTPS redirects must not downgrade to HTTP",
         ));
     }
-    if !url.username().is_empty() || url.password().is_some() {
-        return Err(link_resolution_failure(
-            label,
-            value,
-            "userinfo is not allowed",
-        ));
-    }
-    Ok(url)
+    Ok(())
 }
 
 fn resolution_error(label: &str, url: &str, source: ureq::Error) -> Error {
@@ -513,5 +520,26 @@ mod tests {
         ));
         assert_eq!(source.finish(), vec!["HEAD /issues/11 HTTP/1.1"]);
         assert_eq!(target.finish(), vec!["HEAD /test-server-shutdown HTTP/1.1"]);
+    }
+
+    #[test]
+    fn rejects_https_redirect_downgrades() {
+        let current = Url::parse("https://example.com/issues/12").expect("current URL");
+        let next = Url::parse("http://example.com/pull/12").expect("next URL");
+
+        let error = validate_redirect_transition("#12", &current, &next)
+            .expect_err("HTTPS downgrade must fail");
+
+        assert!(matches!(
+            error,
+            Error::LinkResolutionFailed { ref label, ref reason, .. }
+                if label == "#12" && reason.contains("downgrade")
+        ));
+    }
+
+    #[test]
+    fn allows_private_hosts_for_configured_self_hosted_trackers() {
+        assert!(validate_http_url("http://127.0.0.1/issues/13").is_ok());
+        assert!(validate_http_url("https://10.0.0.1/issues/13").is_ok());
     }
 }

--- a/crates/sacho/src/released.rs
+++ b/crates/sacho/src/released.rs
@@ -2,14 +2,16 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use comrak::nodes::{AstNode, ListType, NodeValue, Sourcepos};
 use comrak::{Arena, Options as ComrakOptions, format_commonmark, parse_document};
+use serde::Serialize;
 
 use crate::changelog::{ReleasedSection, UnreleasedRegionSpan};
 use crate::config::SectionConfig;
 use crate::error::{Error, Result};
+use crate::fragment::{is_complete_reference_label, validate_resolved_link};
 use crate::markdown::format_markdown;
 use crate::repo::Repository;
 
@@ -70,6 +72,18 @@ struct TargetSection<'a> {
 struct ParsedEntry {
     section: Option<String>,
     item_markdown: String,
+    links: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct FragmentContents {
+    items: Vec<String>,
+    links: BTreeMap<String, String>,
+}
+
+#[derive(Serialize)]
+struct FragmentFrontmatter<'a> {
+    links: &'a BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -176,34 +190,33 @@ pub fn carry_release(repo: &Repository, changelog: &str, version: &str) -> Resul
         }
     })?;
     let entries = parse_entries(repo, target.body)?;
-    let mut grouped = BTreeMap::<Option<String>, Vec<String>>::new();
+    let mut grouped = BTreeMap::<Option<String>, FragmentContents>::new();
     for entry in entries {
-        grouped
-            .entry(entry.section)
-            .or_default()
-            .push(entry.item_markdown);
+        merge_fragment_entry(&mut grouped, entry)?;
     }
 
     let mut fragments = Vec::new();
     if repo.config().sections.is_empty() {
-        let items = grouped.remove(&None).unwrap_or_default();
-        if !items.is_empty() {
+        let contents = grouped.remove(&None).unwrap_or_default();
+        if !contents.items.is_empty() {
+            let path = carried_fragment_path(repo, None, version)?;
             fragments.push(CarriedFragment {
                 section: None,
-                path: carried_fragment_path(repo, None, version)?,
-                markdown: fragment_markdown(items),
+                markdown: fragment_markdown(&path, contents)?,
+                path,
             });
         }
     } else {
         for section in &repo.config().sections {
             let section_id = Some(section.id.clone());
-            let Some(items) = grouped.remove(&section_id) else {
+            let Some(contents) = grouped.remove(&section_id) else {
                 continue;
             };
+            let path = carried_fragment_path(repo, Some(section), version)?;
             fragments.push(CarriedFragment {
                 section: section_id,
-                path: carried_fragment_path(repo, Some(section), version)?,
-                markdown: fragment_markdown(items),
+                markdown: fragment_markdown(&path, contents)?,
+                path,
             });
         }
     }
@@ -224,7 +237,7 @@ pub fn import_unreleased_region(repo: &Repository, region: &str) -> Result<Impor
     let arena = Arena::new();
     let root = parse_document(&arena, region, &comrak_options());
     let line_starts = line_starts(region);
-    let references = reference_definitions(region);
+    let references = configured_reference_definitions(repo, region);
     let mut version = None;
     let mut saw_heading = false;
     let mut current_section = None;
@@ -280,14 +293,12 @@ pub fn import_unreleased_region(repo: &Repository, region: &str) -> Result<Impor
                 for item in child.children() {
                     let source = slice_item_sourcepos(region, &line_starts, item.data().sourcepos)
                         .unwrap_or_default();
+                    let (item_markdown, links) =
+                        fold_item_references(source, item, &line_starts, &references)?;
                     entries.push(ParsedEntry {
                         section: current_section.clone(),
-                        item_markdown: fold_item_references(
-                            source,
-                            item,
-                            &line_starts,
-                            &references,
-                        ),
+                        item_markdown,
+                        links,
                     });
                 }
             }
@@ -322,38 +333,37 @@ fn fragments_from_entries(
     entries: Vec<ParsedEntry>,
     filename: &str,
 ) -> Result<Vec<CarriedFragment>> {
-    let mut grouped = BTreeMap::<Option<String>, Vec<String>>::new();
+    let mut grouped = BTreeMap::<Option<String>, FragmentContents>::new();
     for entry in entries {
-        grouped
-            .entry(entry.section)
-            .or_default()
-            .push(entry.item_markdown);
+        merge_fragment_entry(&mut grouped, entry)?;
     }
     let mut fragments = Vec::new();
     if repo.config().sections.is_empty() {
-        let items = grouped.remove(&None).unwrap_or_default();
-        if !items.is_empty() {
+        let contents = grouped.remove(&None).unwrap_or_default();
+        if !contents.items.is_empty() {
+            let path = repo.config().fragments.directory.join(filename);
             fragments.push(CarriedFragment {
                 section: None,
-                path: repo.config().fragments.directory.join(filename),
-                markdown: fragment_markdown(items),
+                markdown: fragment_markdown(&path, contents)?,
+                path,
             });
         }
     } else {
         for section in &repo.config().sections {
             let section_id = Some(section.id.clone());
-            let Some(items) = grouped.remove(&section_id) else {
+            let Some(contents) = grouped.remove(&section_id) else {
                 continue;
             };
+            let path = repo
+                .config()
+                .fragments
+                .directory
+                .join(&section.directory)
+                .join(filename);
             fragments.push(CarriedFragment {
                 section: section_id,
-                path: repo
-                    .config()
-                    .fragments
-                    .directory
-                    .join(&section.directory)
-                    .join(filename),
-                markdown: fragment_markdown(items),
+                markdown: fragment_markdown(&path, contents)?,
+                path,
             });
         }
     }
@@ -540,13 +550,46 @@ fn validate_carried_filename(filename: &str) -> Result<()> {
     Ok(())
 }
 
-fn fragment_markdown(items: Vec<String>) -> String {
+fn merge_fragment_entry(
+    grouped: &mut BTreeMap<Option<String>, FragmentContents>,
+    entry: ParsedEntry,
+) -> Result<()> {
+    let contents = grouped.entry(entry.section).or_default();
+    for (label, url) in &entry.links {
+        if let Some(existing) = contents.links.get(label)
+            && existing != url
+        {
+            return Err(Error::ConflictingResolvedLinks {
+                label: label.clone(),
+                first: existing.clone(),
+                second: url.clone(),
+            });
+        }
+    }
+    contents.items.push(entry.item_markdown);
+    contents.links.extend(entry.links);
+    Ok(())
+}
+
+fn fragment_markdown(path: &Path, contents: FragmentContents) -> Result<String> {
     let mut markdown = String::new();
-    for item in items {
+    if !contents.links.is_empty() {
+        let serialized = serde_yaml_ng::to_string(&FragmentFrontmatter {
+            links: &contents.links,
+        })
+        .map_err(|source| Error::Fragment {
+            path: path.to_path_buf(),
+            source: crate::FragmentError::Frontmatter { source },
+        })?;
+        markdown.push_str("---\n");
+        markdown.push_str(serialized.trim_start_matches("---\n").trim_end());
+        markdown.push_str("\n---\n");
+    }
+    for item in contents.items {
         markdown.push_str(item.trim_end());
         markdown.push('\n');
     }
-    markdown
+    Ok(markdown)
 }
 
 fn find_target_section<'a>(
@@ -585,7 +628,7 @@ fn parse_entries(repo: &Repository, body: &str) -> Result<Vec<ParsedEntry>> {
     let line_starts = line_starts(body);
     let mut entries = Vec::new();
     let mut current_section = None;
-    let references = reference_definitions(body);
+    let references = configured_reference_definitions(repo, body);
 
     for child in root.children() {
         let value = child.data().value.clone();
@@ -604,10 +647,12 @@ fn parse_entries(repo: &Repository, body: &str) -> Result<Vec<ParsedEntry>> {
                 for item in child.children() {
                     let source = slice_item_sourcepos(body, &line_starts, item.data().sourcepos)
                         .unwrap_or_default();
-                    let markdown = fold_item_references(source, item, &line_starts, &references);
+                    let (item_markdown, links) =
+                        fold_item_references(source, item, &line_starts, &references)?;
                     entries.push(ParsedEntry {
                         section: current_section.clone(),
-                        item_markdown: markdown,
+                        item_markdown,
+                        links,
                     });
                 }
             }
@@ -638,21 +683,23 @@ fn fold_item_references<'a>(
     item: &'a AstNode<'a>,
     line_starts: &[usize],
     references: &[ReferenceDefinition],
-) -> String {
+) -> Result<(String, BTreeMap<String, String>)> {
     let item_start_offset = item_source_start_offset(line_starts, item.data().sourcepos)
         .unwrap_or_else(|| {
             sourcepos_start_offset(line_starts, item.data().sourcepos.start).unwrap_or(0)
         });
     let mut replacements = Vec::<(usize, usize, String)>::new();
-    let mut labels_for_item = BTreeSet::<String>::new();
+    let mut labels = BTreeSet::<String>::new();
+    let mut links = BTreeMap::<String, String>::new();
     collect_link_replacements(
         item,
         references,
         line_starts,
         item_start_offset,
         &mut replacements,
-        &mut labels_for_item,
-    );
+        &mut labels,
+        &mut links,
+    )?;
 
     replacements.sort_by_key(|(start, _, _)| *start);
     let mut output = source.to_owned();
@@ -660,12 +707,12 @@ fn fold_item_references<'a>(
         output.replace_range(start..end, &replacement);
     }
 
-    for label in labels_for_item {
+    for label in labels {
         if !output.contains(&format!("[{label}]")) {
             append_reference_label(&mut output, &label);
         }
     }
-    output.trim_end().to_owned()
+    Ok((output.trim_end().to_owned(), links))
 }
 
 fn collect_link_replacements<'a>(
@@ -674,15 +721,28 @@ fn collect_link_replacements<'a>(
     line_starts: &[usize],
     item_start_offset: usize,
     replacements: &mut Vec<(usize, usize, String)>,
-    labels_for_item: &mut BTreeSet<String>,
-) {
+    labels: &mut BTreeSet<String>,
+    links: &mut BTreeMap<String, String>,
+) -> Result<()> {
     if let NodeValue::Link(link) = &node.data().value
         && let Some(reference) = references
             .iter()
             .find(|reference| reference.url == link.url)
     {
         let label_text = plain_text(node).trim().to_owned();
-        labels_for_item.insert(reference.label.clone());
+        labels.insert(reference.label.clone());
+        if validate_resolved_link(&reference.label, &reference.url).is_ok() {
+            if let Some(existing) = links.get(&reference.label)
+                && existing != &reference.url
+            {
+                return Err(Error::ConflictingResolvedLinks {
+                    label: reference.label.clone(),
+                    first: existing.clone(),
+                    second: reference.url.clone(),
+                });
+            }
+            links.insert(reference.label.clone(), reference.url.clone());
+        }
         if label_text == reference.label
             && let Some((start, end)) = sourcepos_offsets(line_starts, node.data().sourcepos)
         {
@@ -700,9 +760,11 @@ fn collect_link_replacements<'a>(
             line_starts,
             item_start_offset,
             replacements,
-            labels_for_item,
-        );
+            labels,
+            links,
+        )?;
     }
+    Ok(())
 }
 
 fn append_reference_label(markdown: &mut String, label: &str) {
@@ -734,6 +796,13 @@ fn reference_definitions(source: &str) -> Vec<ReferenceDefinition> {
     }
     definitions.sort_by(|left, right| left.label.cmp(&right.label));
     definitions
+}
+
+fn configured_reference_definitions(repo: &Repository, source: &str) -> Vec<ReferenceDefinition> {
+    reference_definitions(source)
+        .into_iter()
+        .filter(|reference| is_complete_reference_label(&reference.label, &repo.config().links))
+        .collect()
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1592,6 +1661,279 @@ Released on July 7, 2026.
     }
 
     #[test]
+    fn preserves_folded_reference_definitions_as_carried_fragment_pins() {
+        let (_temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        let changelog = "\
+Version 1.1.5
+-------------
+
+Released on July 7, 2026.
+
+ -  Fixed carry.  [[#8](https://example.com/pull/8)]
+
+[#8]: https://example.com/pull/8
+";
+
+        let carried = carry_release(&repo, changelog, "1.1.5").expect("carry");
+        let fragment = crate::fragment::parse_fragment(
+            carried.fragments[0].path.clone(),
+            &carried.fragments[0].markdown,
+            None,
+            &repo.config().links,
+        )
+        .expect("carried fragment");
+
+        assert_eq!(
+            fragment.links,
+            BTreeMap::from([(
+                String::from("#8"),
+                String::from("https://example.com/pull/8"),
+            )])
+        );
+        assert_eq!(fragment.items[0].references[0].label, "#8");
+    }
+
+    #[test]
+    fn preserves_folded_reference_definitions_as_imported_fragment_pins() {
+        let (_temp, repo) = repo_with_config(
+            r##"
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        let region = "\
+Unreleased
+----------
+
+To be released.
+
+ -  Fixed import.  [[#9](https://example.com/discussions/9)]
+
+[#9]: https://example.com/discussions/9
+";
+
+        let imported = import_unreleased_region(&repo, region).expect("import");
+        let fragment = crate::fragment::parse_fragment(
+            imported.fragments[0].path.clone(),
+            &imported.fragments[0].markdown,
+            None,
+            &repo.config().links,
+        )
+        .expect("imported fragment");
+
+        assert_eq!(
+            fragment.links,
+            BTreeMap::from([(
+                String::from("#9"),
+                String::from("https://example.com/discussions/9"),
+            )])
+        );
+        assert_eq!(fragment.items[0].references[0].label, "#9");
+    }
+
+    #[test]
+    fn rejects_conflicting_reference_definitions_during_decompilation() {
+        let (_temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        let changelog = "\
+Version 1.1.5
+-------------
+
+Released today.
+
+ -  Fixed the first path.  [[#8](https://example.com/pull/8)]
+ -  Fixed the second path.  [[#8](https://example.net/pull/8)]
+
+[#8]: https://example.com/pull/8
+[#8]: https://example.net/pull/8
+";
+        let region = "\
+Unreleased
+----------
+
+To be released.
+
+ -  Fixed the first path.  [[#8](https://example.com/pull/8)]
+ -  Fixed the second path.  [[#8](https://example.net/pull/8)]
+
+[#8]: https://example.com/pull/8
+[#8]: https://example.net/pull/8
+";
+
+        for result in [
+            carry_release(&repo, changelog, "1.1.5"),
+            import_unreleased_region(&repo, region).map(|imported| CarriedRelease {
+                version: imported.version.unwrap_or_default(),
+                fragments: imported.fragments,
+            }),
+        ] {
+            let error = result.expect_err("conflicting definitions");
+            assert!(matches!(
+                error,
+                Error::ConflictingResolvedLinks { ref label, ref first, ref second }
+                    if label == "#8"
+                        && first == "https://example.com/pull/8"
+                        && second == "https://example.net/pull/8"
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_conflicting_reference_definitions_within_one_entry() {
+        let (_temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        let changelog = "\
+Version 1.1.5
+-------------
+
+Released today.
+
+ -  Fixed both [[#8](https://example.com/pull/8)] and [[#8](https://example.net/pull/8)].
+
+[#8]: https://example.com/pull/8
+[#8]: https://example.net/pull/8
+";
+        let region = "\
+Unreleased
+----------
+
+To be released.
+
+ -  Fixed both [[#8](https://example.com/pull/8)] and [[#8](https://example.net/pull/8)].
+
+[#8]: https://example.com/pull/8
+[#8]: https://example.net/pull/8
+";
+
+        for result in [
+            carry_release(&repo, changelog, "1.1.5"),
+            import_unreleased_region(&repo, region).map(|imported| CarriedRelease {
+                version: imported.version.unwrap_or_default(),
+                fragments: imported.fragments,
+            }),
+        ] {
+            let error = result.expect_err("conflicting definitions");
+            assert!(matches!(
+                error,
+                Error::ConflictingResolvedLinks { ref label, ref first, ref second }
+                    if label == "#8"
+                        && first == "https://example.com/pull/8"
+                        && second == "https://example.net/pull/8"
+            ));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn decompiled_reference_pins_preserve_generated_destinations(
+            number in 1_u64..=u32::MAX.into(),
+            destination in prop_oneof![Just("pull"), Just("discussions")],
+        ) {
+            let (_temp, repo) = repo_with_config(
+                r##"
+                [changelog]
+                materialize = false
+
+                [links]
+                "#" = "https://example.com/issues/{n}"
+                "##,
+            );
+            let label = format!("#{number}");
+            let url = format!("https://example.com/{destination}/{number}");
+            let changelog = format!(
+                "Version 1.1.5\n-------------\n\nReleased today.\n\n -  Fixed carry.  [[{label}]({url})]\n\n[{label}]: {url}\n"
+            );
+            let region = format!(
+                "Unreleased\n----------\n\nTo be released.\n\n -  Fixed import.  [[{label}]({url})]\n\n[{label}]: {url}\n"
+            );
+
+            let carried = carry_release(&repo, &changelog, "1.1.5").expect("carry");
+            let imported = import_unreleased_region(&repo, &region).expect("import");
+
+            for output in [&carried.fragments[0], &imported.fragments[0]] {
+                let fragment = crate::fragment::parse_fragment(
+                    output.path.clone(),
+                    &output.markdown,
+                    None,
+                    &repo.config().links,
+                )
+                .expect("decompiled fragment");
+                prop_assert_eq!(fragment.links.get(&label), Some(&url));
+            }
+        }
+
+        #[test]
+        fn decompiled_non_http_references_remain_unpinned(
+            number in 1_u64..=u32::MAX.into(),
+            relative in any::<bool>(),
+        ) {
+            let template = if relative {
+                "/issues/{n}"
+            } else {
+                "mailto:issue-{n}@example.com"
+            };
+            let config = format!(
+                "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{template}\"\n"
+            );
+            let (_temp, repo) = repo_with_config(&config);
+            let label = format!("#{number}");
+            let url = template.replace("{n}", &number.to_string());
+            let changelog = format!(
+                "Version 1.1.5\n-------------\n\nReleased today.\n\n -  Fixed carry.  [[{label}]({url})]\n\n[{label}]: {url}\n"
+            );
+            let region = format!(
+                "Unreleased\n----------\n\nTo be released.\n\n -  Fixed import.  [[{label}]({url})]\n\n[{label}]: {url}\n"
+            );
+
+            let carried = carry_release(&repo, &changelog, "1.1.5").expect("carry");
+            let imported = import_unreleased_region(&repo, &region).expect("import");
+
+            for output in [&carried.fragments[0], &imported.fragments[0]] {
+                let fragment = crate::fragment::parse_fragment(
+                    output.path.clone(),
+                    &output.markdown,
+                    None,
+                    &repo.config().links,
+                )
+                .expect("decompiled fragment");
+                prop_assert!(fragment.links.is_empty());
+                prop_assert_eq!(&fragment.items[0].references[0].label, &label);
+                let compiled = crate::compile::compile_parsed_fragments(
+                    &repo,
+                    crate::compile::CompileOptions::default(),
+                    crate::compile::VersionLabel::Unreleased,
+                    vec![fragment],
+                )
+                .expect("compiled fragment");
+                let definition = format!("[{label}]: {url}");
+                prop_assert!(compiled.markdown.contains(&definition));
+            }
+        }
+    }
+
+    #[test]
     fn appends_reference_label_when_link_text_does_not_identify_reference() {
         let (_temp, repo) = repo_with_config(
             r##"
@@ -1619,6 +1961,97 @@ Released on July 7, 2026.
             carried.fragments[0]
                 .markdown
                 .contains(" -  Fixed carry.  [issue](https://example.com/issues/8)  [[#8]]\n")
+        );
+    }
+
+    #[test]
+    fn leaves_ordinary_markdown_reference_definitions_out_of_fragment_pins() {
+        let (_temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "https://example.com/issues/{n}"
+            "##,
+        );
+        let changelog = "\
+Version 1.1.5
+-------------
+
+Released on July 7, 2026.
+
+ -  Read the [documentation](https://example.com/docs).
+
+[docs]: https://example.com/docs
+";
+        let region = "\
+Unreleased
+----------
+
+To be released.
+
+ -  Read the [documentation](https://example.com/docs).
+
+[docs]: https://example.com/docs
+";
+
+        let carried = carry_release(&repo, changelog, "1.1.5").expect("carry");
+        let imported = import_unreleased_region(&repo, region).expect("import");
+
+        for output in [&carried.fragments[0], &imported.fragments[0]] {
+            let fragment = crate::fragment::parse_fragment(
+                output.path.clone(),
+                &output.markdown,
+                None,
+                &repo.config().links,
+            )
+            .expect("ordinary references must remain valid Markdown");
+            assert!(fragment.links.is_empty());
+            assert_eq!(
+                fragment.items[0].markdown,
+                "-  Read the [documentation](https://example.com/docs)."
+            );
+        }
+    }
+
+    #[test]
+    fn appends_unpinned_relative_reference_when_link_text_does_not_identify_it() {
+        let (_temp, repo) = repo_with_config(
+            r##"
+            [changelog]
+            materialize = false
+
+            [links]
+            "#" = "/issues/{n}"
+            "##,
+        );
+        let changelog = "\
+Version 1.1.5
+-------------
+
+Released on July 7, 2026.
+
+ -  Fixed carry.  [issue](/issues/8)
+
+[#8]: /issues/8
+";
+
+        let carried = carry_release(&repo, changelog, "1.1.5").expect("carry");
+        let fragment = crate::fragment::parse_fragment(
+            carried.fragments[0].path.clone(),
+            &carried.fragments[0].markdown,
+            None,
+            &repo.config().links,
+        )
+        .expect("carried fragment");
+
+        assert!(fragment.links.is_empty());
+        assert_eq!(fragment.items[0].references[0].label, "#8");
+        assert!(
+            carried.fragments[0]
+                .markdown
+                .contains(" -  Fixed carry.  [issue](/issues/8)  [[#8]]\n")
         );
     }
 

--- a/crates/sacho/tests/cli.rs
+++ b/crates/sacho/tests/cli.rs
@@ -1,8 +1,88 @@
 use assert_cmd::Command;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use predicates::prelude::*;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::process::Command as ProcessCommand;
+use std::thread;
+
+struct OneRequestHandle {
+    address: SocketAddr,
+    handle: Option<thread::JoinHandle<String>>,
+}
+
+impl OneRequestHandle {
+    fn join(mut self) -> thread::Result<String> {
+        self.wake();
+        self.handle.take().expect("handle").join()
+    }
+
+    fn wake(&self) {
+        if let Ok(mut stream) = TcpStream::connect(self.address) {
+            let _ = stream.write_all(b"HEAD /test-server-shutdown HTTP/1.1\r\n\r\n");
+        }
+    }
+}
+
+impl Drop for OneRequestHandle {
+    fn drop(&mut self) {
+        let Some(handle) = self.handle.take() else {
+            return;
+        };
+        self.wake();
+        let _ = handle.join();
+    }
+}
+
+fn one_request_http_server() -> (String, OneRequestHandle) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+    let address = listener.local_addr().expect("address");
+    let base = format!("http://{address}");
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("connection");
+        let request = BufReader::new(&stream)
+            .lines()
+            .next()
+            .expect("request line")
+            .expect("request contents");
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")
+            .expect("response");
+        request
+    });
+    (
+        base,
+        OneRequestHandle {
+            address,
+            handle: Some(handle),
+        },
+    )
+}
+
+fn redirecting_http_server() -> (String, thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("listener");
+    let address = listener.local_addr().expect("address");
+    let base = format!("http://{address}");
+    let handle = thread::spawn(move || {
+        let mut requests = Vec::new();
+        for response in [
+            "HTTP/1.1 302 Found\r\nConnection: close\r\nLocation: /pull/3\r\nContent-Length: 0\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+        ] {
+            let (mut stream, _) = listener.accept().expect("connection");
+            requests.push(
+                BufReader::new(&stream)
+                    .lines()
+                    .next()
+                    .expect("request line")
+                    .expect("request contents"),
+            );
+            stream.write_all(response.as_bytes()).expect("response");
+        }
+        requests
+    });
+    (base, handle)
+}
 
 #[cfg(unix)]
 #[test]
@@ -26,6 +106,7 @@ fn repository_commands_reject_an_external_configured_path_without_touching_it() 
         &["next", "1.2.0"],
         &["check", "--fix"],
         &["fmt"],
+        &["resolve-links"],
         &["preview"],
         &["show", "1.1.0"],
         &["sync", "--force"],
@@ -822,6 +903,150 @@ fn preview_prints_empty_unreleased_region() {
 }
 
 #[test]
+fn preview_uses_configured_link_resolution_without_writing_fragments() {
+    let (base, request) = one_request_http_server();
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        temp.path().join("sacho.toml"),
+        format!(
+            "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{base}/issues/{{n}}\"\n\n[link-resolution]\nenabled = true\n"
+        ),
+    )
+    .expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    let path = temp.path().join("changes.d/change.md");
+    let source = " -  Fixed preview links.  [[#1]]\n";
+    std::fs::write(&path, source).expect("fragment");
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .current_dir(temp.path())
+        .arg("preview")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!("[#1]: {base}/issues/1")));
+
+    assert_eq!(std::fs::read_to_string(path).expect("fragment"), source);
+    assert_eq!(request.join().expect("server"), "HEAD /issues/1 HTTP/1.1");
+}
+
+#[test]
+fn preview_no_resolve_links_overrides_enabled_configuration() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        temp.path().join("sacho.toml"),
+        "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"http://127.0.0.1:1/issues/{n}\"\n\n[link-resolution]\nenabled = true\n",
+    )
+    .expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    std::fs::write(
+        temp.path().join("changes.d/change.md"),
+        " -  Fixed preview links.  [[#1]]\n",
+    )
+    .expect("fragment");
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .current_dir(temp.path())
+        .args(["preview", "--no-resolve-links"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "[#1]: http://127.0.0.1:1/issues/1",
+        ));
+}
+
+#[test]
+fn sync_resolve_links_pins_fragments_without_materialization() {
+    let (base, request) = one_request_http_server();
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        temp.path().join("sacho.toml"),
+        format!("[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{base}/issues/{{n}}\"\n"),
+    )
+    .expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    let path = temp.path().join("changes.d/change.md");
+    std::fs::write(&path, " -  Fixed sync links.  [[#2]]\n").expect("fragment");
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .current_dir(temp.path())
+        .args(["sync", "--resolve-links"])
+        .assert()
+        .success();
+
+    let fragment = std::fs::read_to_string(path).expect("fragment");
+    assert!(fragment.contains("links:"));
+    assert!(fragment.contains(&format!("{base}/issues/2")));
+    assert_eq!(request.join().expect("server"), "HEAD /issues/2 HTTP/1.1");
+}
+
+#[test]
+fn release_resolve_links_uses_the_resolving_plan() {
+    let (base, requests) = redirecting_http_server();
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        temp.path().join("sacho.toml"),
+        format!("[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{base}/issues/{{n}}\"\n"),
+    )
+    .expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    let fragment = temp.path().join("changes.d/change.md");
+    std::fs::write(&fragment, " -  Fixed release links.  [[#3]]\n").expect("fragment");
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .current_dir(temp.path())
+        .args([
+            "release",
+            "0.2.0",
+            "--date",
+            "2026-07-08",
+            "--resolve-links",
+        ])
+        .assert()
+        .success();
+
+    assert!(!fragment.exists());
+    assert!(
+        std::fs::read_to_string(temp.path().join("CHANGES.md"))
+            .expect("changelog")
+            .contains(&format!("[#3]: {base}/pull/3"))
+    );
+    assert_eq!(
+        requests.join().expect("server"),
+        vec!["HEAD /issues/3 HTTP/1.1", "HEAD /pull/3 HTTP/1.1"]
+    );
+}
+
+#[test]
+fn resolve_links_command_pins_fragments_without_materialization() {
+    let (base, request) = one_request_http_server();
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        temp.path().join("sacho.toml"),
+        format!("[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"{base}/issues/{{n}}\"\n"),
+    )
+    .expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    let path = temp.path().join("changes.d/change.md");
+    std::fs::write(&path, " -  Fixed standalone links.  [[#4]]\n").expect("fragment");
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .current_dir(temp.path())
+        .arg("resolve-links")
+        .assert()
+        .success();
+
+    let fragment = std::fs::read_to_string(path).expect("fragment");
+    assert!(fragment.contains("links:"));
+    assert!(fragment.contains(&format!("{base}/issues/4")));
+    assert_eq!(request.join().expect("server"), "HEAD /issues/4 HTTP/1.1");
+}
+
+#[test]
 fn preview_rejects_unknown_section() {
     let temp = tempfile::TempDir::new().expect("tempdir");
     std::fs::write(temp.path().join("sacho.toml"), "").expect("config");
@@ -861,7 +1086,22 @@ fn preview_help_describes_section_option() {
         .stdout(predicate::str::contains(
             "Print the compiled unreleased region",
         ))
-        .stdout(predicate::str::contains("Section id to preview by itself"));
+        .stdout(predicate::str::contains("Section id to preview by itself"))
+        .stdout(predicate::str::contains("--resolve-links"))
+        .stdout(predicate::str::contains("--no-resolve-links"));
+}
+
+#[test]
+fn resolve_links_help_describes_persistent_resolution() {
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .args(["resolve-links", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Resolve and pin unpinned reference links",
+        ));
 }
 
 #[test]
@@ -1359,6 +1599,32 @@ materialize = false
 }
 
 #[test]
+fn check_rejects_an_unused_resolved_link_pin() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        temp.path().join("sacho.toml"),
+        "[changelog]\nmaterialize = false\n\n[links]\n\"#\" = \"https://example.com/issues/{n}\"\n",
+    )
+    .expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    std::fs::write(
+        temp.path().join("changes.d/fix.md"),
+        "---\nlinks:\n  '#2': https://example.com/pull/2\n---\n -  Fixed thing.  [[#1]]\n",
+    )
+    .expect("fragment");
+
+    Command::cargo_bin("sacho")
+        .expect("binary")
+        .current_dir(temp.path())
+        .arg("check")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("resolved link label"))
+        .stderr(predicate::str::contains("#2"))
+        .stderr(predicate::str::contains("not used"));
+}
+
+#[test]
 fn sync_force_rewrites_materialized_changelog() {
     let temp = tempfile::TempDir::new().expect("tempdir");
     std::fs::write(temp.path().join("sacho.toml"), "").expect("config");
@@ -1555,6 +1821,53 @@ fn sync_in_terminal_keeps_changelog_after_default_no_confirmation() {
         std::fs::read_to_string(temp.path().join("CHANGES.md")).expect("changelog"),
         original
     );
+}
+
+#[test]
+fn sync_non_terminal_retry_preserves_explicit_link_resolution_policy() {
+    for (flag, enabled, expected, unexpected) in [
+        (
+            "--resolve-links",
+            false,
+            "sacho sync --resolve-links --force",
+            "sacho sync --no-resolve-links --force",
+        ),
+        (
+            "--no-resolve-links",
+            true,
+            "sacho sync --no-resolve-links --force",
+            "sacho sync --resolve-links --force",
+        ),
+    ] {
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        std::fs::write(
+            temp.path().join("sacho.toml"),
+            format!(
+                "[links]\n\"#\" = \"https://example.com/issues/{{n}}\"\n\n[link-resolution]\nenabled = {enabled}\n"
+            ),
+        )
+        .expect("config");
+        std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+        std::fs::write(
+            temp.path().join("changes.d/fix.md"),
+            "---\nlinks:\n  '#1': https://example.com/pull/1\n---\n -  Fixed sync.  [[#1]]\n",
+        )
+        .expect("fragment");
+        std::fs::write(
+            temp.path().join("CHANGES.md"),
+            "Unreleased\n----------\n\nTo be released.\n\nHand-edited note.\n",
+        )
+        .expect("changelog");
+
+        Command::cargo_bin("sacho")
+            .expect("binary")
+            .current_dir(temp.path())
+            .args(["sync", flag])
+            .assert()
+            .code(2)
+            .stderr(predicate::str::contains(expected))
+            .stderr(predicate::str::contains(unexpected).not());
+    }
 }
 
 #[test]
@@ -3049,7 +3362,9 @@ fn release_help_describes_allow_empty() {
         .stdout(predicate::str::contains("--allow-empty"))
         .stdout(predicate::str::contains(
             "Allow a release without changelog items",
-        ));
+        ))
+        .stdout(predicate::str::contains("--resolve-links"))
+        .stdout(predicate::str::contains("--no-resolve-links"));
 }
 
 #[test]

--- a/crates/sacho/tests/cli.rs
+++ b/crates/sacho/tests/cli.rs
@@ -974,7 +974,8 @@ fn sync_resolve_links_pins_fragments_without_materialization() {
         .current_dir(temp.path())
         .args(["sync", "--resolve-links"])
         .assert()
-        .success();
+        .success()
+        .stdout("changes.d/change.md\n");
 
     let fragment = std::fs::read_to_string(path).expect("fragment");
     assert!(fragment.contains("links:"));
@@ -1038,12 +1039,50 @@ fn resolve_links_command_pins_fragments_without_materialization() {
         .current_dir(temp.path())
         .arg("resolve-links")
         .assert()
-        .success();
+        .success()
+        .stdout("changes.d/change.md\n");
 
     let fragment = std::fs::read_to_string(path).expect("fragment");
     assert!(fragment.contains("links:"));
     assert!(fragment.contains(&format!("{base}/issues/4")));
     assert_eq!(request.join().expect("server"), "HEAD /issues/4 HTTP/1.1");
+}
+
+#[test]
+fn resolve_links_command_reports_the_materialized_changelog() {
+    let (base, requests) = redirecting_http_server();
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        temp.path().join("sacho.toml"),
+        format!("[links]\n\"#\" = \"{base}/issues/{{n}}\"\n"),
+    )
+    .expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    std::fs::write(
+        temp.path().join("changes.d/change.md"),
+        " -  Fixed reported links.  [[#5]]\n",
+    )
+    .expect("fragment");
+    std::fs::write(
+        temp.path().join("CHANGES.md"),
+        format!(
+            "Unreleased\n----------\n\nTo be released.\n\n -  Fixed reported links.  [[#5]]\n\n[#5]: {base}/issues/5\n"
+        ),
+    )
+    .expect("changelog");
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .current_dir(temp.path())
+        .arg("resolve-links")
+        .assert()
+        .success()
+        .stdout("changes.d/change.md\nCHANGES.md\n");
+
+    assert_eq!(
+        requests.join().expect("server"),
+        vec!["HEAD /issues/5 HTTP/1.1", "HEAD /pull/3 HTTP/1.1"]
+    );
 }
 
 #[test]

--- a/docs/concepts/fragments.md
+++ b/docs/concepts/fragments.md
@@ -98,3 +98,20 @@ The corresponding URL template belongs in *sacho.toml*:
 
 Sacho emits the link definitions in the compiled changelog. `sacho check`
 reports a reference whose sigil has no configured template.
+
+For trackers that redirect a shared reference route to a more specific target,
+run `sacho resolve-links`. Sacho follows the redirect chain once and pins the
+final URL without moving the reference out of the entry text:
+
+~~~~ markdown
+---
+links:
+  "#842": https://github.com/acme/widget/pull/842
+---
+
+ -  Added `clear()` to remove every entry at once.  [[#842]]
+~~~~
+
+Pins travel with their fragments and take precedence over the repository URL
+template. Each pin key must be a configured reference label used by that
+fragment. Delete a pin to request that reference again.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -98,15 +98,30 @@ discard hand edits, Sacho asks for confirmation in a terminal and refuses the
 change in a noninteractive process.
 
 
+`sacho resolve-links`
+---------------------
+
+~~~~ text
+sacho resolve-links
+~~~~
+
+Follows redirects for every unpinned fragment reference and records each final
+URL in that fragment's frontmatter. Existing pins are not requested again.
+When materialization is enabled, the changelog is synchronized in the same
+failure-safe operation. A network or validation failure leaves every file
+unchanged.
+
+
 `sacho preview`
 ---------------
 
 ~~~~ text
-sacho preview [--section <SECTION>]
+sacho preview [--section <SECTION>] [--resolve-links | --no-resolve-links]
 ~~~~
 
 Prints the compiled unreleased region to standard output without changing
-files. `--section` prints only one configured section.
+files. `--section` prints only one configured section. Link resolution affects
+the output in memory and never writes pins from `preview`.
 
 
 `sacho show`
@@ -131,20 +146,23 @@ does not read the current fragments.
 ------------
 
 ~~~~ text
-sacho sync [--force]
+sacho sync [--force] [--resolve-links | --no-resolve-links]
 ~~~~
 
 Recompiles the materialized unreleased region from the fragments. It does
-nothing when materialization is disabled or the changelog is already current.
+nothing when materialization is disabled or the changelog is already current,
+unless link resolution is enabled and unpinned fragment references remain.
 
 `--force` allows the replacement to discard edits inside the generated region.
+Resolved fragment pins and changelog output are committed atomically.
 
 
 `sacho release`
 ---------------
 
 ~~~~ text
-sacho release [--date <DATE>] [--next <NEXT>] [--allow-empty] [VERSION]
+sacho release [--date <DATE>] [--next <NEXT>] [--allow-empty]
+              [--resolve-links | --no-resolve-links] [VERSION]
 ~~~~
 
 Compiles and inserts a dated released section and removes the consumed
@@ -152,12 +170,14 @@ fragments. Without `--next`, it also removes the next-version file and closes
 the materialized unreleased region. With `--next`, it opens the following cycle
 in the same operation.
 
-| Argument or option | Meaning                                                                |
-| ------------------ | ---------------------------------------------------------------------- |
-| `VERSION`          | Version to release. Defaults to the next-version file.                 |
-| `--date <DATE>`    | Release date in `YYYY-MM-DD` form. Defaults to the current local date. |
-| `--next <NEXT>`    | Open this next version immediately after the release.                  |
-| `--allow-empty`    | Allow a release without substantive changelog items.                   |
+| Argument or option   | Meaning                                                                |
+| -------------------- | ---------------------------------------------------------------------- |
+| `VERSION`            | Version to release. Defaults to the next-version file.                 |
+| `--date <DATE>`      | Release date in `YYYY-MM-DD` form. Defaults to the current local date. |
+| `--next <NEXT>`      | Open this next version immediately after the release.                  |
+| `--allow-empty`      | Allow a release without substantive changelog items.                   |
+| `--resolve-links`    | Resolve unpinned links before compiling the release.                   |
+| `--no-resolve-links` | Disable configured link resolution for this release.                   |
 
 When both `VERSION` and the next-version file contain values, they must agree.
 The first release may have no fragments when the changelog has no released

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -72,6 +72,25 @@ A fragment using `[[#842]]` can then compile a reference definition for issue
 842. Links without a matching sigil fail `sacho check`.
 
 
+`[link-resolution]`
+-------------------
+
+~~~~ toml
+[link-resolution]
+enabled = false
+~~~~
+
+When enabled, `preview`, `sync`, and `release` resolve unpinned reference URLs
+through HTTP redirects by default. The command-line `--resolve-links` and
+`--no-resolve-links` options override this setting. `check`, hooks, and `fmt`
+never make network requests, and unpinned references remain valid.
+
+Resolved URLs are stored in fragment frontmatter. Existing pins are
+authoritative, and every pin key must name a configured reference used by that
+fragment. Remove a pin before resolving again when its destination needs to be
+refreshed.
+
+
 `[vcs]`                                                                   {#vcs}
 --------------------------------------------------------------------------------
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -85,6 +85,12 @@ through HTTP redirects by default. The command-line `--resolve-links` and
 `--no-resolve-links` options override this setting. `check`, hooks, and `fmt`
 never make network requests, and unpinned references remain valid.
 
+Link templates and their redirect targets are trusted repository inputs.
+Resolution can access private network addresses so that repositories can use
+self-hosted trackers. Do not enable it for untrusted repository configuration
+in a privileged network environment. HTTPS redirects may not downgrade to
+HTTP.
+
 Resolved URLs are stored in fragment frontmatter. Existing pins are
 authoritative, and every pin key must name a configured reference used by that
 fragment. Remove a pin before resolving again when its destination needs to be


### PR DESCRIPTION
Issue trackers often use one numeric namespace for several kinds of objects. A configured URL such as `/issues/842` may redirect to `/pull/842`, and that final destination is part of what the changelog entry means. Repeating the lookup whenever Sacho renders a changelog would make output depend on the network and on the forge's current routing rules.

Resolved destinations therefore become fragment state. The final URL is stored in the fragment's `links` frontmatter, next to the prose that uses it. The pin then travels with the entry through rebases, cherry-picks, and merges, which follows the same rule that makes fragments the source of truth in the first place. Compilation remains deterministic once a destination has been resolved.


Keep network access at explicit boundaries
------------------------------------------

Resolution is deliberately opt-in. Repositories can enable it through `[link-resolution]` in *sacho.toml*, while `--resolve-links` and `--no-resolve-links` provide command-level control. `preview` resolves only in memory. `sync` and `release` can resolve as part of their existing workflows, and `resolve-links` provides an explicit way to persist pins ahead of either operation.

Commands used in hooks and CI remain offline. In particular, `check` and `fmt` never make HTTP requests, so enabling resolution does not turn routine validation into a network-dependent step. Relative and non-HTTP templates also remain ordinary unpinned references rather than becoming permanent resolution errors.

The HTTP path follows redirects itself instead of delegating policy to the client. Every hop must use HTTP or HTTPS and must not contain user information. The chain has a fixed limit, `HEAD` falls back to a ranged `GET` when necessary, and one client is shared across a resolution batch so connections can be reused. Errors redact credentials before they reach diagnostics.


Plan every request before writing
---------------------------------

Network work happens during planning, before Sacho changes the repository. The planner reads the fragment set, resolves each shared label once, and builds the complete after-state for fragments and the materialized *CHANGES.md*. The mutation lock then protects a second snapshot check before the planned writes are applied as one repository transaction.

This keeps the failure rule simple: a redirect error, an invalid destination, or a stale fragment leaves every file unchanged. A section-scoped preview requests only references used by that section, but still honors authoritative pins found elsewhere. A resolving release compiles from the resolved snapshots before consuming its fragments, so it does not need an intermediate write.


Preserve meaning across carry and import
----------------------------------------

Released changelogs can already contain destinations that differ from the configured template. `carry` and `import-unreleased` now recover those destinations as pins when they decompile representable entries. Ordinary Markdown reference definitions are left alone, and non-HTTP references remain unpinned.

The decompiler checks for conflicts before moving destinations into per-item and per-section maps. Compilation compares pins across fragments. A disagreement returns an error instead of silently choosing one URL and changing what another reference points to when the fragment is compiled again.


Verification
------------

Unit, property, and integration tests cover redirect chains, HTTP fallback, validation and redaction, stale plans, section scoping, decompilation, and the CLI entry points. `mise run test` and `mise run check` pass. The full mutation suite has not been run.
