### PR TITLE
Separate release note wrapping from changelog formatting

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -415,7 +415,8 @@ jobs:
           mkdir release-notes-bin
           tar --extract --xz --file "$archive" --directory release-notes-bin
           release-notes-bin/sacho \
-            show "$VERSION" --skip-heading --output-file release-notes.md
+            show "$VERSION" --skip-heading --no-word-wrap \
+            --output-file release-notes.md
       - name: Publish the GitHub Release
         shell: bash
         env:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.3.0
 
 To be released.
 
+ -  Added `--no-word-wrap` to `sacho preview` and `sacho show` for publishing
+    release notes without Sacho's canonical 80-column wrapping.  [[#3]]
+
+[#3]: https://github.com/dahlia/sacho/pull/3
+
 
 Version 0.2.0
 -------------

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ can run:
 
 ~~~~ sh
 version="${GITHUB_REF_NAME#v}"
-sacho show "$version" --skip-heading --output-file release-notes.md
+sacho show "$version" --skip-heading --no-word-wrap --output-file release-notes.md
 gh release create "$GITHUB_REF_NAME" --notes-file release-notes.md
 ~~~~
 

--- a/changes.d/no-word-wrap.md
+++ b/changes.d/no-word-wrap.md
@@ -1,0 +1,6 @@
+---
+links:
+  '#3': https://github.com/dahlia/sacho/pull/3
+---
+ -  Added `--no-word-wrap` to `sacho preview` and `sacho show` for publishing
+    release notes without Sacho's canonical 80-column wrapping.  [[#3]]

--- a/crates/sacho/src/cli.rs
+++ b/crates/sacho/src/cli.rs
@@ -147,6 +147,10 @@ enum Command {
             help = "Do not resolve unpinned reference links"
         )]
         no_resolve_links: bool,
+
+        /// Do not word-wrap the rendered Markdown.
+        #[arg(long, help = "Do not word-wrap the output")]
+        no_word_wrap: bool,
     },
 
     /// Print a released changelog section.
@@ -167,6 +171,10 @@ enum Command {
             help = "Write the released section to a file"
         )]
         output_file: Option<PathBuf>,
+
+        /// Do not word-wrap the rendered Markdown.
+        #[arg(long, help = "Do not word-wrap the output")]
+        no_word_wrap: bool,
     },
 
     /// Regenerate the materialized unreleased changelog region.
@@ -374,6 +382,7 @@ impl Cli {
                 section,
                 resolve_links,
                 no_resolve_links,
+                no_word_wrap,
             } => {
                 let repo = Repository::open_existing(".").map_err(CliReport::from)?;
                 let compiled = compile_unreleased_with_link_resolution(
@@ -381,6 +390,7 @@ impl Cli {
                     CompileOptions {
                         section,
                         include_empty_region: true,
+                        word_wrap: !no_word_wrap,
                     },
                     link_resolution_policy(resolve_links, no_resolve_links),
                 )?;
@@ -391,6 +401,7 @@ impl Cli {
                 version,
                 skip_heading,
                 output_file,
+                no_word_wrap,
             } => {
                 let repo = Repository::open_existing(".").map_err(CliReport::from)?;
                 let released = show(
@@ -398,6 +409,7 @@ impl Cli {
                     ShowOptions {
                         version,
                         skip_heading,
+                        word_wrap: !no_word_wrap,
                     },
                 )?;
                 if let Some(path) = output_file {

--- a/crates/sacho/src/commands.rs
+++ b/crates/sacho/src/commands.rs
@@ -518,6 +518,9 @@ pub struct ShowOptions {
 
     /// Whether to omit the released version heading from the returned Markdown.
     pub skip_heading: bool,
+
+    /// Whether to wrap returned Markdown at Sacho's canonical line width.
+    pub word_wrap: bool,
 }
 
 /// Result of carrying released entries.
@@ -1718,6 +1721,7 @@ pub fn show(repo: &Repository, options: ShowOptions) -> Result<ReleasedSection> 
         &options.version,
         unreleased_region,
         options.skip_heading,
+        options.word_wrap,
     )?
     .ok_or(Error::ReleasedVersionNotFound {
         version: options.version,

--- a/crates/sacho/src/compile.rs
+++ b/crates/sacho/src/compile.rs
@@ -3,16 +3,13 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
-use hongdown::{
-    DashSetting, IndentWidth, LeadingSpaces, LineWidth, Options as HongdownOptions, TrailingSpaces,
-    UnorderedMarker, format,
-};
 use indexmap::IndexMap;
 use snafu::ResultExt;
 
 use crate::config::{ReferenceSigil, UrlTemplate};
 use crate::error::{ReadFileSnafu, Result};
 use crate::fragment::{Fragment, ReferenceUse, discover_fragments};
+use crate::markdown::format_markdown_with_word_wrap;
 use crate::repo::Repository;
 
 /// Rendered section identifier.
@@ -27,6 +24,9 @@ pub struct CompileOptions {
     /// Whether to include the version heading and date line when no entries
     /// are available.
     pub include_empty_region: bool,
+
+    /// Whether to wrap rendered Markdown at Sacho's canonical line width.
+    pub word_wrap: bool,
 }
 
 impl Default for CompileOptions {
@@ -34,6 +34,7 @@ impl Default for CompileOptions {
         Self {
             section: None,
             include_empty_region: true,
+            word_wrap: true,
         }
     }
 }
@@ -183,6 +184,7 @@ pub(crate) fn compile_parsed_fragments(
             &version_label,
             &config.changelog.unreleased_heading,
             &sections,
+            options.word_wrap,
         )?
     };
 
@@ -443,6 +445,7 @@ fn format_region(
     version_label: &VersionLabel,
     unreleased_heading: &str,
     sections: &[CompiledSection],
+    word_wrap: bool,
 ) -> Result<String> {
     let mut header = String::new();
     header.push_str("## ");
@@ -451,17 +454,11 @@ fn format_region(
     header.push_str(unreleased_heading);
     header.push('\n');
 
-    let options = hongdown_options();
-    let mut markdown = format(&header, &options).map_err(|source| crate::Error::Format {
-        source: Box::new(source),
-    })?;
+    let mut markdown = format_markdown_with_word_wrap(&header, word_wrap)?;
     for section in sections {
         markdown.push('\n');
-        let section_markdown = format(section.markdown.trim_end(), &options).map_err(|source| {
-            crate::Error::Format {
-                source: Box::new(source),
-            }
-        })?;
+        let section_markdown =
+            format_markdown_with_word_wrap(section.markdown.trim_end(), word_wrap)?;
         markdown.push_str(section_markdown.trim_end());
         markdown.push('\n');
         if !section.references.is_empty() {
@@ -480,21 +477,6 @@ fn append_reference_definitions(markdown: &mut String, references: &[CompiledRef
         markdown.push_str("]: ");
         markdown.push_str(&reference.url);
         markdown.push('\n');
-    }
-}
-
-fn hongdown_options() -> HongdownOptions {
-    HongdownOptions {
-        line_width: Some(LineWidth::new(80).expect("80 is a valid line width")),
-        unordered_marker: UnorderedMarker::Hyphen,
-        leading_spaces: LeadingSpaces::new(1).expect("1 is valid leading spaces"),
-        trailing_spaces: TrailingSpaces::new(2).expect("2 is valid trailing spaces"),
-        indent_width: IndentWidth::new(4).expect("4 is a valid indent width"),
-        curly_double_quotes: false,
-        curly_single_quotes: false,
-        ellipsis: false,
-        em_dash: DashSetting::Disabled,
-        ..HongdownOptions::default()
     }
 }
 

--- a/crates/sacho/src/markdown.rs
+++ b/crates/sacho/src/markdown.rs
@@ -12,14 +12,18 @@ pub struct FormattedMarkdown {
 }
 
 pub(crate) fn format_markdown(source: &str) -> Result<String> {
-    hongdown::format(source, &hongdown_options()).map_err(|source| Error::Format {
+    format_markdown_with_word_wrap(source, true)
+}
+
+pub(crate) fn format_markdown_with_word_wrap(source: &str, word_wrap: bool) -> Result<String> {
+    hongdown::format(source, &hongdown_options(word_wrap)).map_err(|source| Error::Format {
         source: Box::new(source),
     })
 }
 
-fn hongdown_options() -> Options {
+fn hongdown_options(word_wrap: bool) -> Options {
     Options {
-        line_width: Some(LineWidth::new(80).expect("80 is a valid line width")),
+        line_width: word_wrap.then(|| LineWidth::new(80).expect("80 is a valid line width")),
         unordered_marker: UnorderedMarker::Hyphen,
         leading_spaces: LeadingSpaces::new(1).expect("1 is valid leading spaces"),
         trailing_spaces: TrailingSpaces::new(2).expect("2 is valid trailing spaces"),
@@ -29,5 +33,38 @@ fn hongdown_options() -> Options {
         ellipsis: false,
         em_dash: DashSetting::Disabled,
         ..Options::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn no_word_wrap_is_independent_of_soft_break_position(
+            words in prop::collection::vec("[a-z]{1,12}", 2..24),
+            split_seed in any::<usize>(),
+        ) {
+            let split = split_seed % (words.len() - 1) + 1;
+            let source = format!(
+                " -  {}\n    {}\n",
+                words[..split].join(" "),
+                words[split..].join(" "),
+            );
+            let expected = format!(" -  {}\n", words.join(" "));
+
+            let formatted =
+                format_markdown_with_word_wrap(&source, false).expect("format without wrapping");
+
+            prop_assert_eq!(&formatted, &expected);
+            prop_assert_eq!(
+                format_markdown_with_word_wrap(&formatted, false)
+                    .expect("reformat without wrapping"),
+                formatted,
+            );
+        }
     }
 }

--- a/crates/sacho/src/released.rs
+++ b/crates/sacho/src/released.rs
@@ -12,7 +12,7 @@ use crate::changelog::{ReleasedSection, UnreleasedRegionSpan};
 use crate::config::SectionConfig;
 use crate::error::{Error, Result};
 use crate::fragment::{is_complete_reference_label, validate_resolved_link};
-use crate::markdown::format_markdown;
+use crate::markdown::format_markdown_with_word_wrap;
 use crate::repo::Repository;
 
 /// Entries decompiled from a released changelog section.
@@ -423,11 +423,12 @@ pub(crate) fn render_released_section(
     version: &str,
     unreleased_region: Option<UnreleasedRegionSpan>,
     skip_heading: bool,
+    word_wrap: bool,
 ) -> Result<Option<ReleasedSection>> {
     let Some(target) = find_target_section(source, version, unreleased_region) else {
         return Ok(None);
     };
-    let markdown = render_target_section(source, &target, skip_heading)?;
+    let markdown = render_target_section(source, &target, skip_heading, word_wrap)?;
     Ok(Some(ReleasedSection {
         version: version.to_owned(),
         markdown,
@@ -438,6 +439,7 @@ fn render_target_section(
     source: &str,
     target: &TargetSection<'_>,
     skip_heading: bool,
+    word_wrap: bool,
 ) -> Result<String> {
     let arena = Arena::new();
     let options = comrak_options();
@@ -469,7 +471,7 @@ fn render_target_section(
     let mut rendered = String::new();
     format_commonmark(section, &options, &mut rendered)
         .expect("writing CommonMark to a String cannot fail");
-    format_markdown(&rendered)
+    format_markdown_with_word_wrap(&rendered, word_wrap)
 }
 
 fn referenced_footnote_definitions<'a>(

--- a/crates/sacho/tests/cli.rs
+++ b/crates/sacho/tests/cli.rs
@@ -903,6 +903,58 @@ fn preview_prints_empty_unreleased_region() {
 }
 
 #[test]
+fn preview_no_word_wrap_joins_soft_breaks_and_preserves_hard_breaks() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(temp.path().join("sacho.toml"), "").expect("config");
+    std::fs::create_dir_all(temp.path().join("changes.d")).expect("fragments dir");
+    std::fs::write(
+        temp.path().join("changes.d/no-word-wrap.md"),
+        concat!(
+            " -  Added a deliberately long release note that must stay on one physical line ",
+            "when it is published through GitHub Releases.  ",
+            "\n",
+            "    This intentional hard break remains visible.\n",
+        ),
+    )
+    .expect("fragment");
+    let mut wrapped_command = Command::cargo_bin("sacho").expect("binary");
+    let wrapped_output = wrapped_command
+        .current_dir(temp.path())
+        .arg("preview")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let wrapped_output = String::from_utf8(wrapped_output).expect("UTF-8 preview");
+    assert!(
+        wrapped_output.lines().all(|line| line.len() <= 80),
+        "{wrapped_output}"
+    );
+    assert!(!wrapped_output.contains(
+        " -  Added a deliberately long release note that must stay on one physical line when it is published through GitHub Releases."
+    ));
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .current_dir(temp.path())
+        .args(["preview", "--no-word-wrap"])
+        .assert()
+        .success()
+        .stdout(concat!(
+            "Unreleased\n",
+            "----------\n",
+            "\n",
+            "To be released.\n",
+            "\n",
+            " -  Added a deliberately long release note that must stay on one physical line ",
+            "when it is published through GitHub Releases.  ",
+            "\n",
+            "    This intentional hard break remains visible.\n",
+        ));
+}
+
+#[test]
 fn preview_uses_configured_link_resolution_without_writing_fragments() {
     let (base, request) = one_request_http_server();
     let temp = tempfile::TempDir::new().expect("tempdir");
@@ -1127,7 +1179,9 @@ fn preview_help_describes_section_option() {
         ))
         .stdout(predicate::str::contains("Section id to preview by itself"))
         .stdout(predicate::str::contains("--resolve-links"))
-        .stdout(predicate::str::contains("--no-resolve-links"));
+        .stdout(predicate::str::contains("--no-resolve-links"))
+        .stdout(predicate::str::contains("--no-word-wrap"))
+        .stdout(predicate::str::contains("Do not word-wrap the output"));
 }
 
 #[test]
@@ -1244,6 +1298,75 @@ Released on July 19, 2026.
 ",
             );
     }
+}
+
+#[test]
+fn show_no_word_wrap_writes_unwrapped_release_notes_to_a_file() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    std::fs::write(
+        temp.path().join("sacho.toml"),
+        "[changelog]\nmaterialize = false\n",
+    )
+    .expect("config");
+    std::fs::write(
+        temp.path().join("CHANGES.md"),
+        concat!(
+            "Version 1.2.0\n",
+            "-------------\n",
+            "\n",
+            "Released on July 19, 2026.\n",
+            "\n",
+            " -  Added a deliberately long release note that must stay on one physical line ",
+            "when it is published through GitHub Releases.  ",
+            "\n",
+            "    This intentional hard break remains visible.\n",
+        ),
+    )
+    .expect("changelog");
+    let mut wrapped_command = Command::cargo_bin("sacho").expect("binary");
+    let wrapped_output = wrapped_command
+        .current_dir(temp.path())
+        .args(["show", "1.2.0"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let wrapped_output = String::from_utf8(wrapped_output).expect("UTF-8 released section");
+    assert!(
+        wrapped_output.lines().all(|line| line.len() <= 80),
+        "{wrapped_output}"
+    );
+    assert!(!wrapped_output.contains(
+        " -  Added a deliberately long release note that must stay on one physical line when it is published through GitHub Releases."
+    ));
+    let mut command = Command::cargo_bin("sacho").expect("binary");
+
+    command
+        .current_dir(temp.path())
+        .args([
+            "show",
+            "1.2.0",
+            "--skip-heading",
+            "--no-word-wrap",
+            "--output-file",
+            "release-notes.md",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("release-notes.md")).expect("output"),
+        concat!(
+            "Released on July 19, 2026.\n",
+            "\n",
+            " -  Added a deliberately long release note that must stay on one physical line ",
+            "when it is published through GitHub Releases.  ",
+            "\n",
+            "    This intentional hard break remains visible.\n",
+        )
+    );
 }
 
 #[test]
@@ -1540,7 +1663,9 @@ fn show_help_describes_version_argument() {
         .stdout(predicate::str::contains("-o, --output-file <PATH>"))
         .stdout(predicate::str::contains(
             "Write the released section to a file",
-        ));
+        ))
+        .stdout(predicate::str::contains("--no-word-wrap"))
+        .stdout(predicate::str::contains("Do not word-wrap the output"));
 }
 
 #[test]

--- a/docs/guide/everyday-workflow.md
+++ b/docs/guide/everyday-workflow.md
@@ -71,6 +71,11 @@ Previewing catches editorial problems that fragment-by-fragment review can
 miss: repeated entries, a security fix buried in the sort order, or two notes
 that describe different stages of the same feature.
 
+Use `sacho preview --no-word-wrap` when handing the rendered Markdown to a
+publishing system that displays soft line breaks. The option affects only the
+preview; fragments and the materialized changelog retain Sacho's canonical
+80-column wrapping.
+
 
 Check before committing
 -----------------------

--- a/docs/guide/releases.md
+++ b/docs/guide/releases.md
@@ -89,10 +89,11 @@ sacho show 1.2.0
 ~~~~
 
 Use `--skip-heading` when the release platform already displays the version,
-and `--output-file` to write the result directly:
+`--no-word-wrap` when it displays soft line breaks, and `--output-file` to write
+the result directly:
 
 ~~~~ sh
-sacho show 1.2.0 --skip-heading --output-file release-notes.md
+sacho show 1.2.0 --skip-heading --no-word-wrap --output-file release-notes.md
 ~~~~
 
 A GitHub Actions job triggered by a `v1.2.0` tag can publish that file with the
@@ -100,12 +101,13 @@ GitHub CLI:
 
 ~~~~ sh
 version="${GITHUB_REF_NAME#v}"
-sacho show "$version" --skip-heading --output-file release-notes.md
+sacho show "$version" --skip-heading --no-word-wrap --output-file release-notes.md
 gh release create "$GITHUB_REF_NAME" --notes-file release-notes.md
 ~~~~
 
 `show` reads only released sections. It does not compile current fragments or
-return an unreleased preview.
+return an unreleased preview. The no-wrap rendering changes only the exported
+Markdown and preserves intentional hard breaks.
 
 
 Forward-port release notes

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -117,18 +117,21 @@ unchanged.
 
 ~~~~ text
 sacho preview [--section <SECTION>] [--resolve-links | --no-resolve-links]
+              [--no-word-wrap]
 ~~~~
 
 Prints the compiled unreleased region to standard output without changing
 files. `--section` prints only one configured section. Link resolution affects
-the output in memory and never writes pins from `preview`.
+the output in memory and never writes pins from `preview`. `--no-word-wrap`
+removes automatic 80-column wrapping from the output while preserving explicit
+Markdown hard breaks.
 
 
 `sacho show`
 ------------
 
 ~~~~ text
-sacho show [--skip-heading] [--output-file <PATH>] <VERSION>
+sacho show [--skip-heading] [--output-file <PATH>] [--no-word-wrap] <VERSION>
 ~~~~
 
 Reads a frozen released section from the changelog.
@@ -137,9 +140,12 @@ Reads a frozen released section from the changelog.
 | ---------------------------- | -------------------------------------------------------------------------- |
 | `-H`, `--skip-heading`       | Omit the version heading while preserving the section body and references. |
 | `-o`, `--output-file <PATH>` | Write to a file instead of standard output.                                |
+| `--no-word-wrap`             | Remove automatic 80-column wrapping from the output.                       |
 
 The command reports an error when the requested released version is absent. It
-does not read the current fragments.
+does not read the current fragments. `--no-word-wrap` applies equally to
+standard output and `--output-file`, and preserves explicit Markdown hard
+breaks.
 
 
 `sacho sync`

--- a/skills/sacho/SKILL.md
+++ b/skills/sacho/SKILL.md
@@ -229,14 +229,14 @@ After the release commit, `sacho show` prints one frozen section:
 
 ~~~~ sh
 sacho show 1.2.0
-sacho show 1.2.0 --skip-heading --output-file release-notes.md
+sacho show 1.2.0 --skip-heading --no-word-wrap --output-file release-notes.md
 ~~~~
 
 A tag-triggered GitHub Actions job can hand that file to the GitHub CLI:
 
 ~~~~ sh
 version="${GITHUB_REF_NAME#v}"
-sacho show "$version" --skip-heading --output-file release-notes.md
+sacho show "$version" --skip-heading --no-word-wrap --output-file release-notes.md
 gh release create "$GITHUB_REF_NAME" --notes-file release-notes.md
 ~~~~
 


### PR DESCRIPTION
Rationale
---------

Sacho's 80-column wrapping is part of its canonical changelog format.  It keeps fragments, materialized output, and released history deterministic.  GitHub Releases treats those source line breaks as visible breaks, however, so reusing canonical output there produces awkwardly broken prose.  Changing the canonical format would solve the publishing symptom by weakening a repository-wide invariant.

This change keeps those concerns separate.  Wrapped output remains the default everywhere, while `preview` and `show` can opt into an unwrapped presentation for destinations that need it.


Approach
--------

The wrap choice is carried through `CompileOptions` and `ShowOptions` instead of being implemented as a string-replacement pass at the CLI boundary.  Both paths still use the same Hongdown configuration.  Disabling wrapping only changes `line_width` from 80 to `None`, which lets the formatter join soft breaks while preserving explicit Markdown hard breaks and every other house-style rule.

All mutating commands continue to use the default wrapped mode, so fragments and materialized changelogs cannot accidentally adopt the publication format. The GitHub Release workflow in *.github/workflows/main.yaml* requests `--no-word-wrap` only when exporting release notes, and the publishing examples follow the same boundary.


Verification
------------

The CLI tests compare the default and unwrapped forms for both commands, including `--skip-heading`, file output, and intentional hard breaks.  A property test varies soft-break positions and checks that no-wrap formatting is stable and idempotent.  `mise run test` and `mise run check` pass.